### PR TITLE
feat: add response decoding

### DIFF
--- a/lib/ex_stream_client.ex
+++ b/lib/ex_stream_client.ex
@@ -2,17 +2,4 @@ defmodule ExStreamClient do
   @moduledoc """
   Documentation for `ExStreamClient`.
   """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> ExStreamClient.hello()
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/lib/ex_stream_client/jason.ex
+++ b/lib/ex_stream_client/jason.ex
@@ -14,6 +14,43 @@ defmodule ExStreamClient.Jason do
           |> Jason.Encode.map(opts)
         end
       end
+
+      @doc """
+      Build a struct from a map, transforming nested components and atom fields.
+      """
+      def decode(map) when is_map(map) do
+        processed =
+          Enum.reduce(nested_components(), map, fn {key, type_or_mod}, acc ->
+            case Map.fetch(acc, key) do
+              {:ok, val} -> Map.put(acc, key, transform(val, type_or_mod))
+              :error -> acc
+            end
+          end)
+
+        struct(__MODULE__, processed)
+      end
+
+      defp transform(val, :atom) when is_binary(val), do: String.to_existing_atom(val)
+      defp transform(val, :atom) when is_list(val), do: Enum.map(val, &String.to_existing_atom/1)
+
+      defp transform(val, mod) when is_list(val) and is_atom(mod) do
+        if Code.ensure_loaded?(mod) and function_exported?(mod, :decode, 1) do
+          Enum.map(val, &mod.decode/1)
+        else
+          val
+        end
+      end
+
+      defp transform(val, mod) when is_map(val) and is_atom(mod) do
+        if Code.ensure_loaded?(mod) and function_exported?(mod, :decode, 1) do
+          mod.decode(val)
+        else
+          val
+        end
+      end
+
+      # Fallback
+      defp transform(val, _), do: val
     end
   end
 end

--- a/mix/tasks/generate.ex
+++ b/mix/tasks/generate.ex
@@ -13,5 +13,8 @@ defmodule Mix.Tasks.Gen.Client do
 
     Codegen.GenerateModel.run(docs)
     Codegen.GenerateOperations.run(docs)
+
+    Mix.Task.reenable("format")
+    Mix.Task.run("format", ["lib/**/*.ex"])
   end
 end


### PR DESCRIPTION
Adds response decoding - including nested structs and enums.

It does this by adding a new metadata field on model components

```elixir
defmodule ExStreamClient.Model.SomeComponent do
   ...

   @nested_components %{action: :atom, severity_rules: ExStreamClient.Model.BodyguardSeverityRule}
   
   def nested_components do
    @nested_components
   end

   ...

end
```

This allows us to expand the `Jason` helper module to handle decoding keys based on this property. 

The result is you get something like this: 

```elixir
message = %{action: "bounce_remove", label: "foo", min_confidence: 200.0}
config = %{async: true, enabled: false, rules: [message]}
ExStreamClient.Model.AIVideoConfig.decode(config)

%ExStreamClient.Model.AIVideoConfig{
  async: true,
  enabled: false,
  rules: [
    %ExStreamClient.Model.AWSRekognitionRule{
      action: :bounce_remove,
      label: "foo",
      min_confidence: 200.0
    }
  ]
}
```

Also cleans up the client and adds mix formatting. Followup PR will include the model / client generated with these changes.