### PR TITLE
feat: improve generated documentation output

### DIFF
--- a/lib/ex_stream_client/operations/app.ex
+++ b/lib/ex_stream_client/operations/app.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.App do
-  @moduledoc "
-	Modules for interacting with the `app` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `app` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	This Method updates one or more application settings
 
-	
-	### Required Arguments:
-		- `payload`: UpdateAppRequest
-	"
+  @doc ~S"""
+  This Method updates one or more application settings
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateAppRequest`
+  """
   @spec update_app(ExStreamClient.Model.UpdateAppRequest.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def update_app(payload) do
@@ -50,13 +51,11 @@ defmodule ExStreamClient.Operations.App do
     end
   end
 
-  @doc ~S"
-	This Method returns the application settings
+  @doc ~S"""
+  This Method returns the application settings
 
-	
-	### Required Arguments:
-		
-	"
+
+  """
   @spec get_app() :: {:ok, ExStreamClient.Model.GetApplicationResponse.t()} | {:error, any()}
   def get_app() do
     request_opts = [url: "/api/v2/app", method: :get, params: []] ++ []

--- a/lib/ex_stream_client/operations/blocklists.ex
+++ b/lib/ex_stream_client/operations/blocklists.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Blocklists do
-  @moduledoc "
-	Modules for interacting with the `blocklists` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `blocklists` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Creates a new application blocklist, once created the blocklist can be used by any channel type
 
-	
-	### Required Arguments:
-		- `payload`: CreateBlockListRequest
-	"
+  @doc ~S"""
+  Creates a new application blocklist, once created the blocklist can be used by any channel type
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CreateBlockListRequest`
+  """
   @spec create_block_list(ExStreamClient.Model.CreateBlockListRequest.t()) ::
           {:ok, ExStreamClient.Model.CreateBlockListResponse.t()} | {:error, any()}
   def create_block_list(payload) do
@@ -50,15 +51,13 @@ defmodule ExStreamClient.Operations.Blocklists do
     end
   end
 
-  @doc ~S"
-	Returns all available block lists
+  @doc ~S"""
+  Returns all available block lists
 
-	
-	### Required Arguments:
-		
-	### Optional Arguments:
-		- `team`
-	"
+
+  ### Optional Arguments:
+  - `team`
+  """
   @spec list_block_lists() ::
           {:ok, ExStreamClient.Model.ListBlockListResponse.t()} | {:error, any()}
   @spec list_block_lists(team: String.t()) ::
@@ -106,14 +105,14 @@ defmodule ExStreamClient.Operations.Blocklists do
     end
   end
 
-  @doc ~S"
-	Updates contents of the block list
+  @doc ~S"""
+  Updates contents of the block list
 
-	
-	### Required Arguments:
-		- `name`
-		- `payload`: UpdateBlockListRequest
-	"
+
+  ### Required Arguments:
+  - `name`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateBlockListRequest`
+  """
   @spec update_block_list(String.t(), ExStreamClient.Model.UpdateBlockListRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateBlockListResponse.t()} | {:error, any()}
   def update_block_list(name, payload) do
@@ -153,15 +152,15 @@ defmodule ExStreamClient.Operations.Blocklists do
     end
   end
 
-  @doc ~S"
-	Returns block list by given name
+  @doc ~S"""
+  Returns block list by given name
 
-	
-	### Required Arguments:
-		- `name`
-	### Optional Arguments:
-		- `team`
-	"
+
+  ### Required Arguments:
+  - `name`
+  ### Optional Arguments:
+  - `team`
+  """
   @spec get_block_list(String.t()) ::
           {:ok, ExStreamClient.Model.GetBlockListResponse.t()} | {:error, any()}
   @spec get_block_list(String.t(), team: String.t()) ::
@@ -209,15 +208,15 @@ defmodule ExStreamClient.Operations.Blocklists do
     end
   end
 
-  @doc ~S"
-	Deletes previously created application blocklist
+  @doc ~S"""
+  Deletes previously created application blocklist
 
-	
-	### Required Arguments:
-		- `name`
-	### Optional Arguments:
-		- `team`
-	"
+
+  ### Required Arguments:
+  - `name`
+  ### Optional Arguments:
+  - `team`
+  """
   @spec delete_block_list(String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_block_list(String.t(), team: String.t()) ::

--- a/lib/ex_stream_client/operations/chat/campaigns.ex
+++ b/lib/ex_stream_client/operations/chat/campaigns.ex
@@ -1,18 +1,19 @@
 defmodule ExStreamClient.Operations.Chat.Campaigns do
-  @moduledoc "
-	Modules for interacting with the `chat/campaigns` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/campaigns` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Stops a campaign
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: StopCampaignRequest
-	"
+  @doc ~S"""
+  Stops a campaign
+
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.StopCampaignRequest`
+  """
   @spec schedule_campaign(String.t(), ExStreamClient.Model.StopCampaignRequest.t()) ::
           {:ok, ExStreamClient.Model.CampaignResponse.t()} | {:error, any()}
   def schedule_campaign(id, payload) do
@@ -52,13 +53,13 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
     end
   end
 
-  @doc ~S"
-	Query campaigns with filter query
+  @doc ~S"""
+  Query campaigns with filter query
 
-	
-	### Required Arguments:
-		- `payload`: QueryCampaignsRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryCampaignsRequest`
+  """
   @spec query_campaigns(ExStreamClient.Model.QueryCampaignsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryCampaignsResponse.t()} | {:error, any()}
   def query_campaigns(payload) do
@@ -98,17 +99,17 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
     end
   end
 
-  @doc ~S"
-	Get campaign by ID.
+  @doc ~S"""
+  Get campaign by ID.
 
-	
-	### Required Arguments:
-		- `id`
-	### Optional Arguments:
-		- `prev`
-		- `next`
-		- `limit`
-	"
+
+  ### Required Arguments:
+  - `id`
+  ### Optional Arguments:
+  - `prev`
+  - `next`
+  - `limit`
+  """
   @spec get_campaign(String.t()) ::
           {:ok, ExStreamClient.Model.GetCampaignResponse.t()} | {:error, any()}
   @spec get_campaign(String.t(), [{:limit, integer()} | {:next, String.t()} | {:prev, String.t()}]) ::
@@ -156,14 +157,14 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
     end
   end
 
-  @doc ~S"
-	Starts or schedules a campaign
+  @doc ~S"""
+  Starts or schedules a campaign
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: StartCampaignRequest
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.StartCampaignRequest`
+  """
   @spec start_campaign(String.t(), ExStreamClient.Model.StartCampaignRequest.t()) ::
           {:ok, ExStreamClient.Model.StartCampaignResponse.t()} | {:error, any()}
   def start_campaign(id, payload) do

--- a/lib/ex_stream_client/operations/chat/channels.ex
+++ b/lib/ex_stream_client/operations/chat/channels.ex
@@ -1,21 +1,22 @@
 defmodule ExStreamClient.Operations.Chat.Channels do
-  @moduledoc "
-	Modules for interacting with the `chat/channels` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/channels` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: UpdateMemberPartialRequest
-	### Optional Arguments:
-		- `user_id`
-	"
+  @doc ~S"""
+
+
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateMemberPartialRequest`
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec update_member_partial(
           String.t(),
           String.t(),
@@ -70,15 +71,15 @@ defmodule ExStreamClient.Operations.Chat.Channels do
     end
   end
 
-  @doc ~S"
-	Marks channel as unread from a specific message
+  @doc ~S"""
+  Marks channel as unread from a specific message
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: MarkUnreadRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.MarkUnreadRequest`
+  """
   @spec mark_unread(String.t(), String.t(), ExStreamClient.Model.MarkUnreadRequest.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def mark_unread(type, id, payload) do
@@ -119,17 +120,17 @@ defmodule ExStreamClient.Operations.Chat.Channels do
     end
   end
 
-  @doc ~S"
-	Marks channels as read up to the specific message. If no channels is given, mark all channel as read
+  @doc ~S"""
+  Marks channels as read up to the specific message. If no channels is given, mark all channel as read
 
-Sends events:
-- message.read
-- message.read
+  ### Sends events:
+  - `message.read`
+  - `message.read`
 
-	
-	### Required Arguments:
-		- `payload`: MarkChannelsReadRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.MarkChannelsReadRequest`
+  """
   @spec mark_channels_read(ExStreamClient.Model.MarkChannelsReadRequest.t()) ::
           {:ok, ExStreamClient.Model.MarkReadResponse.t()} | {:error, any()}
   def mark_channels_read(payload) do
@@ -169,19 +170,19 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Marks channel as hidden for current user
+  @doc ~S"""
+  Marks channel as hidden for current user
 
-Sends events:
-- channel.hidden
-- channel.hidden
+  ### Sends events:
+  - `channel.hidden`
+  - `channel.hidden`
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: HideChannelRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.HideChannelRequest`
+  """
   @spec hide_channel(String.t(), String.t(), ExStreamClient.Model.HideChannelRequest.t()) ::
           {:ok, ExStreamClient.Model.HideChannelResponse.t()} | {:error, any()}
   def hide_channel(type, id, payload) do
@@ -222,22 +223,22 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	This Method creates a channel or returns an existing one with matching attributes
+  @doc ~S"""
+  This Method creates a channel or returns an existing one with matching attributes
 
-Sends events:
-- channel.created
-- member.added
-- member.removed
-- member.updated
-- user.watching.start
+  ### Sends events:
+  - `channel.created`
+  - `member.added`
+  - `member.removed`
+  - `member.updated`
+  - `user.watching.start`
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: ChannelGetOrCreateRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.ChannelGetOrCreateRequest`
+  """
   @spec get_or_create_channel(
           String.t(),
           String.t(),
@@ -281,13 +282,13 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Query channels with filter query
+  @doc ~S"""
+  Query channels with filter query
 
-	
-	### Required Arguments:
-		- `payload`: QueryChannelsRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryChannelsRequest`
+  """
   @spec query_channels(ExStreamClient.Model.QueryChannelsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryChannelsResponse.t()} | {:error, any()}
   def query_channels(payload) do
@@ -326,21 +327,21 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Sends new message to the specified channel
+  @doc ~S"""
+  Sends new message to the specified channel
 
-Sends events:
-- message.new
-- message.updated
-- message.new
-- message.updated
+  ### Sends events:
+  - `message.new`
+  - `message.updated`
+  - `message.new`
+  - `message.updated`
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: SendMessageRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.SendMessageRequest`
+  """
   @spec send_message(String.t(), String.t(), ExStreamClient.Model.SendMessageRequest.t()) ::
           {:ok, ExStreamClient.Model.SendMessageResponse.t()} | {:error, any()}
   def send_message(type, id, payload) do
@@ -381,19 +382,19 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Truncates messages from a channel. Can be applied to the entire channel or scoped to specific members.
+  @doc ~S"""
+  Truncates messages from a channel. Can be applied to the entire channel or scoped to specific members.
 
-Sends events:
-- channel.truncated
-- channel.truncated
+  ### Sends events:
+  - `channel.truncated`
+  - `channel.truncated`
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: TruncateChannelRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.TruncateChannelRequest`
+  """
   @spec truncate_channel(String.t(), String.t(), ExStreamClient.Model.TruncateChannelRequest.t()) ::
           {:ok, ExStreamClient.Model.TruncateChannelResponse.t()} | {:error, any()}
   def truncate_channel(type, id, payload) do
@@ -434,19 +435,19 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Shows previously hidden channel
+  @doc ~S"""
+  Shows previously hidden channel
 
-Sends events:
-- channel.visible
-- channel.visible
+  ### Sends events:
+  - `channel.visible`
+  - `channel.visible`
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: ShowChannelRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.ShowChannelRequest`
+  """
   @spec show_channel(String.t(), String.t(), ExStreamClient.Model.ShowChannelRequest.t()) ::
           {:ok, ExStreamClient.Model.ShowChannelResponse.t()} | {:error, any()}
   def show_channel(type, id, payload) do
@@ -487,15 +488,15 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Returns list messages found by IDs
+  @doc ~S"""
+  Returns list messages found by IDs
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `ids`
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `ids`
+  """
   @spec get_many_messages(String.t(), String.t(), list()) ::
           {:ok, ExStreamClient.Model.GetManyMessagesResponse.t()} | {:error, any()}
   def get_many_messages(type, id, ids) do
@@ -536,15 +537,15 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Sends event to the channel
+  @doc ~S"""
+  Sends event to the channel
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: SendEventRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.SendEventRequest`
+  """
   @spec send_event(String.t(), String.t(), ExStreamClient.Model.SendEventRequest.t()) ::
           {:ok, ExStreamClient.Model.EventResponse.t()} | {:error, any()}
   def send_event(type, id, payload) do
@@ -585,17 +586,17 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Get a draft
+  @doc ~S"""
+  Get a draft
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-	### Optional Arguments:
-		- `parent_id`
-		- `user_id`
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  ### Optional Arguments:
+  - `parent_id`
+  - `user_id`
+  """
   @spec get_draft(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.GetDraftResponse.t()} | {:error, any()}
   @spec get_draft(String.t(), String.t(), [{:user_id, String.t()} | {:parent_id, String.t()}]) ::
@@ -643,20 +644,20 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Deletes a draft
+  @doc ~S"""
+  Deletes a draft
 
-Sends events:
-- draft.deleted
+  ### Sends events:
+  - `draft.deleted`
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-	### Optional Arguments:
-		- `parent_id`
-		- `user_id`
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  ### Optional Arguments:
+  - `parent_id`
+  - `user_id`
+  """
   @spec delete_draft(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_draft(String.t(), String.t(), [{:user_id, String.t()} | {:parent_id, String.t()}]) ::
@@ -704,15 +705,15 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Uploads file
+  @doc ~S"""
+  Uploads file
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: FileUploadRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.FileUploadRequest`
+  """
   @spec upload_file(String.t(), String.t(), ExStreamClient.Model.FileUploadRequest.t()) ::
           {:ok, ExStreamClient.Model.FileUploadResponse.t()} | {:error, any()}
   def upload_file(type, id, payload) do
@@ -753,16 +754,16 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Deletes previously uploaded file
+  @doc ~S"""
+  Deletes previously uploaded file
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-	### Optional Arguments:
-		- `url`
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  ### Optional Arguments:
+  - `url`
+  """
   @spec delete_file(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_file(String.t(), String.t(), url: String.t()) ::
@@ -810,19 +811,19 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Marks channel as read up to the specific message
+  @doc ~S"""
+  Marks channel as read up to the specific message
 
-Sends events:
-- message.read
-- message.read
+  ### Sends events:
+  - `message.read`
+  - `message.read`
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: MarkReadRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.MarkReadRequest`
+  """
   @spec mark_read(String.t(), String.t(), ExStreamClient.Model.MarkReadRequest.t()) ::
           {:ok, ExStreamClient.Model.MarkReadResponse.t()} | {:error, any()}
   def mark_read(type, id, payload) do
@@ -863,15 +864,15 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Uploads image
+  @doc ~S"""
+  Uploads image
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: ImageUploadRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.ImageUploadRequest`
+  """
   @spec upload_image(String.t(), String.t(), ExStreamClient.Model.ImageUploadRequest.t()) ::
           {:ok, ExStreamClient.Model.ImageUploadResponse.t()} | {:error, any()}
   def upload_image(type, id, payload) do
@@ -912,16 +913,16 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Deletes previously uploaded image
+  @doc ~S"""
+  Deletes previously uploaded image
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-	### Optional Arguments:
-		- `url`
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  ### Optional Arguments:
+  - `url`
+  """
   @spec delete_image(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_image(String.t(), String.t(), url: String.t()) ::
@@ -969,21 +970,21 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	This Method creates a channel or returns an existing one with matching attributes
+  @doc ~S"""
+  This Method creates a channel or returns an existing one with matching attributes
 
-Sends events:
-- channel.created
-- member.added
-- member.removed
-- member.updated
-- user.watching.start
+  ### Sends events:
+  - `channel.created`
+  - `member.added`
+  - `member.removed`
+  - `member.updated`
+  - `user.watching.start`
 
-	
-	### Required Arguments:
-		- `type`
-		- `payload`: ChannelGetOrCreateRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `payload`: `Elixir.ExStreamClient.Model.ChannelGetOrCreateRequest`
+  """
   @spec get_or_create_distinct_channel(
           String.t(),
           ExStreamClient.Model.ChannelGetOrCreateRequest.t()
@@ -1025,27 +1026,27 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Change channel data
+  @doc ~S"""
+  Change channel data
 
-Sends events:
-- channel.updated
-- member.added
-- member.removed
-- member.updated
-- message.new
-- channel.updated
-- member.added
-- member.removed
-- member.updated
-- message.new
+  ### Sends events:
+  - `channel.updated`
+  - `member.added`
+  - `member.removed`
+  - `member.updated`
+  - `message.new`
+  - `channel.updated`
+  - `member.added`
+  - `member.removed`
+  - `member.updated`
+  - `message.new`
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: UpdateChannelRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateChannelRequest`
+  """
   @spec update_channel(String.t(), String.t(), ExStreamClient.Model.UpdateChannelRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateChannelResponse.t()} | {:error, any()}
   def update_channel(type, id, payload) do
@@ -1085,19 +1086,19 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Updates certain fields of the channel
+  @doc ~S"""
+  Updates certain fields of the channel
 
-Sends events:
-- channel.updated
-- channel.updated
+  ### Sends events:
+  - `channel.updated`
+  - `channel.updated`
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-		- `payload`: UpdateChannelPartialRequest
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateChannelPartialRequest`
+  """
   @spec update_channel_partial(
           String.t(),
           String.t(),
@@ -1140,20 +1141,20 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Deletes channel
+  @doc ~S"""
+  Deletes channel
 
-Sends events:
-- channel.deleted
-- channel.deleted
+  ### Sends events:
+  - `channel.deleted`
+  - `channel.deleted`
 
-	
-	### Required Arguments:
-		- `type`
-		- `id`
-	### Optional Arguments:
-		- `hard_delete`
-	"
+
+  ### Required Arguments:
+  - `type`
+  - `id`
+  ### Optional Arguments:
+  - `hard_delete`
+  """
   @spec delete_channel(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.DeleteChannelResponse.t()} | {:error, any()}
   @spec delete_channel(String.t(), String.t(), hard_delete: boolean()) ::
@@ -1201,17 +1202,17 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Allows to delete several channels at once asynchronously
+  @doc ~S"""
+  Allows to delete several channels at once asynchronously
 
-Sends events:
-- channel.deleted
-- channel.deleted
+  ### Sends events:
+  - `channel.deleted`
+  - `channel.deleted`
 
-	
-	### Required Arguments:
-		- `payload`: DeleteChannelsRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.DeleteChannelsRequest`
+  """
   @spec delete_channels(ExStreamClient.Model.DeleteChannelsRequest.t()) ::
           {:ok, ExStreamClient.Model.DeleteChannelsResponse.t()} | {:error, any()}
   def delete_channels(payload) do

--- a/lib/ex_stream_client/operations/chat/channeltypes.ex
+++ b/lib/ex_stream_client/operations/chat/channeltypes.ex
@@ -1,18 +1,19 @@
 defmodule ExStreamClient.Operations.Chat.Channeltypes do
-  @moduledoc "
-	Modules for interacting with the `chat/channeltypes` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/channeltypes` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Updates channel type
 
-	
-	### Required Arguments:
-		- `name`
-		- `payload`: UpdateChannelTypeRequest
-	"
+  @doc ~S"""
+  Updates channel type
+
+
+  ### Required Arguments:
+  - `name`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateChannelTypeRequest`
+  """
   @spec update_channel_type(String.t(), ExStreamClient.Model.UpdateChannelTypeRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateChannelTypeResponse.t()} | {:error, any()}
   def update_channel_type(name, payload) do
@@ -52,13 +53,13 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
     end
   end
 
-  @doc ~S"
-	Gets channel type
+  @doc ~S"""
+  Gets channel type
 
-	
-	### Required Arguments:
-		- `name`
-	"
+
+  ### Required Arguments:
+  - `name`
+  """
   @spec get_channel_type(String.t()) ::
           {:ok, ExStreamClient.Model.GetChannelTypeResponse.t()} | {:error, any()}
   def get_channel_type(name) do
@@ -97,13 +98,13 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
     end
   end
 
-  @doc ~S"
-	Deletes channel type
+  @doc ~S"""
+  Deletes channel type
 
-	
-	### Required Arguments:
-		- `name`
-	"
+
+  ### Required Arguments:
+  - `name`
+  """
   @spec delete_channel_type(String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_channel_type(name) do
@@ -142,13 +143,13 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
     end
   end
 
-  @doc ~S"
-	Creates new channel type
+  @doc ~S"""
+  Creates new channel type
 
-	
-	### Required Arguments:
-		- `payload`: CreateChannelTypeRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CreateChannelTypeRequest`
+  """
   @spec create_channel_type(ExStreamClient.Model.CreateChannelTypeRequest.t()) ::
           {:ok, ExStreamClient.Model.CreateChannelTypeResponse.t()} | {:error, any()}
   def create_channel_type(payload) do
@@ -188,13 +189,11 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
     end
   end
 
-  @doc ~S"
-	Lists all available channel types
+  @doc ~S"""
+  Lists all available channel types
 
-	
-	### Required Arguments:
-		
-	"
+
+  """
   @spec list_channel_types() ::
           {:ok, ExStreamClient.Model.ListChannelTypesResponse.t()} | {:error, any()}
   def list_channel_types() do

--- a/lib/ex_stream_client/operations/chat/commands.ex
+++ b/lib/ex_stream_client/operations/chat/commands.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Chat.Commands do
-  @moduledoc "
-	Modules for interacting with the `chat/commands` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/commands` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Creates custom chat command
 
-	
-	### Required Arguments:
-		- `payload`: CreateCommandRequest
-	"
+  @doc ~S"""
+  Creates custom chat command
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CreateCommandRequest`
+  """
   @spec create_command(ExStreamClient.Model.CreateCommandRequest.t()) ::
           {:ok, ExStreamClient.Model.CreateCommandResponse.t()} | {:error, any()}
   def create_command(payload) do
@@ -50,13 +51,11 @@ defmodule ExStreamClient.Operations.Chat.Commands do
     end
   end
 
-  @doc ~S"
-	Returns all custom commands
+  @doc ~S"""
+  Returns all custom commands
 
-	
-	### Required Arguments:
-		
-	"
+
+  """
   @spec list_commands() :: {:ok, ExStreamClient.Model.ListCommandsResponse.t()} | {:error, any()}
   def list_commands() do
     request_opts = [url: "/api/v2/chat/commands", method: :get, params: []] ++ []
@@ -94,14 +93,14 @@ defmodule ExStreamClient.Operations.Chat.Commands do
     end
   end
 
-  @doc ~S"
-	Updates custom chat command
+  @doc ~S"""
+  Updates custom chat command
 
-	
-	### Required Arguments:
-		- `name`
-		- `payload`: UpdateCommandRequest
-	"
+
+  ### Required Arguments:
+  - `name`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateCommandRequest`
+  """
   @spec update_command(String.t(), ExStreamClient.Model.UpdateCommandRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateCommandResponse.t()} | {:error, any()}
   def update_command(name, payload) do
@@ -141,13 +140,13 @@ defmodule ExStreamClient.Operations.Chat.Commands do
     end
   end
 
-  @doc ~S"
-	Returns custom command by its name
+  @doc ~S"""
+  Returns custom command by its name
 
-	
-	### Required Arguments:
-		- `name`
-	"
+
+  ### Required Arguments:
+  - `name`
+  """
   @spec get_command(String.t()) ::
           {:ok, ExStreamClient.Model.GetCommandResponse.t()} | {:error, any()}
   def get_command(name) do
@@ -186,13 +185,13 @@ defmodule ExStreamClient.Operations.Chat.Commands do
     end
   end
 
-  @doc ~S"
-	Deletes custom chat command
+  @doc ~S"""
+  Deletes custom chat command
 
-	
-	### Required Arguments:
-		- `name`
-	"
+
+  ### Required Arguments:
+  - `name`
+  """
   @spec delete_command(String.t()) ::
           {:ok, ExStreamClient.Model.DeleteCommandResponse.t()} | {:error, any()}
   def delete_command(name) do

--- a/lib/ex_stream_client/operations/chat/drafts.ex
+++ b/lib/ex_stream_client/operations/chat/drafts.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Chat.Drafts do
-  @moduledoc "
-	Modules for interacting with the `chat/drafts` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/drafts` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Queries draft messages for a user
 
-	
-	### Required Arguments:
-		- `payload`: QueryDraftsRequest
-	"
+  @doc ~S"""
+  Queries draft messages for a user
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryDraftsRequest`
+  """
   @spec query_drafts(ExStreamClient.Model.QueryDraftsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryDraftsResponse.t()} | {:error, any()}
   def query_drafts(payload) do

--- a/lib/ex_stream_client/operations/chat/export_channels.ex
+++ b/lib/ex_stream_client/operations/chat/export_channels.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Chat.ExportChannels do
-  @moduledoc "
-	Modules for interacting with the `chat/export_channels` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/export_channels` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Exports channel data to JSON file
 
-	
-	### Required Arguments:
-		- `payload`: ExportChannelsRequest
-	"
+  @doc ~S"""
+  Exports channel data to JSON file
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.ExportChannelsRequest`
+  """
   @spec export_channels(ExStreamClient.Model.ExportChannelsRequest.t()) ::
           {:ok, ExStreamClient.Model.ExportChannelsResponse.t()} | {:error, any()}
   def export_channels(payload) do

--- a/lib/ex_stream_client/operations/chat/members.ex
+++ b/lib/ex_stream_client/operations/chat/members.ex
@@ -1,19 +1,18 @@
 defmodule ExStreamClient.Operations.Chat.Members do
-  @moduledoc "
-	Modules for interacting with the `chat/members` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/members` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Find and filter channel members
 
-	
-	### Required Arguments:
-		
-	### Optional Arguments:
-		- `payload`: QueryMembersPayload
-	"
+  @doc ~S"""
+  Find and filter channel members
+
+
+  ### Optional Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryMembersPayload`
+  """
   @spec query_members() :: {:ok, ExStreamClient.Model.MembersResponse.t()} | {:error, any()}
   @spec query_members(payload: ExStreamClient.Model.QueryMembersPayload.t()) ::
           {:ok, ExStreamClient.Model.MembersResponse.t()} | {:error, any()}

--- a/lib/ex_stream_client/operations/chat/messages.ex
+++ b/lib/ex_stream_client/operations/chat/messages.ex
@@ -1,24 +1,25 @@
 defmodule ExStreamClient.Operations.Chat.Messages do
-  @moduledoc "
-	Modules for interacting with the `chat/messages` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/messages` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Delete a vote from a poll
 
-Sends events:
-- poll.vote_removed
+  @doc ~S"""
+  Delete a vote from a poll
 
-	
-	### Required Arguments:
-		- `message_id`
-		- `poll_id`
-		- `vote_id`
-	### Optional Arguments:
-		- `user_id`
-	"
+  ### Sends events:
+  - `poll.vote_removed`
+
+
+  ### Required Arguments:
+  - `message_id`
+  - `poll_id`
+  - `vote_id`
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec remove_poll_vote(String.t(), String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.PollVoteResponse.t()} | {:error, any()}
   @spec remove_poll_vote(String.t(), String.t(), String.t(), user_id: String.t()) ::
@@ -66,19 +67,19 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Removes user reaction from the message
+  @doc ~S"""
+  Removes user reaction from the message
 
-Sends events:
-- reaction.deleted
+  ### Sends events:
+  - `reaction.deleted`
 
-	
-	### Required Arguments:
-		- `id`
-		- `type`
-	### Optional Arguments:
-		- `user_id`
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `type`
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec delete_reaction(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.DeleteReactionResponse.t()} | {:error, any()}
   @spec delete_reaction(String.t(), String.t(), user_id: String.t()) ::
@@ -126,18 +127,18 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Sends reaction to specified message
+  @doc ~S"""
+  Sends reaction to specified message
 
-Sends events:
-- reaction.new
-- reaction.updated
+  ### Sends events:
+  - `reaction.new`
+  - `reaction.updated`
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: SendReactionRequest
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.SendReactionRequest`
+  """
   @spec send_reaction(String.t(), ExStreamClient.Model.SendReactionRequest.t()) ::
           {:ok, ExStreamClient.Model.SendReactionResponse.t()} | {:error, any()}
   def send_reaction(id, payload) do
@@ -177,18 +178,18 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Executes message command action with given parameters
+  @doc ~S"""
+  Executes message command action with given parameters
 
-Sends events:
-- message.new
-- message.new
+  ### Sends events:
+  - `message.new`
+  - `message.new`
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: MessageActionRequest
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.MessageActionRequest`
+  """
   @spec run_message_action(String.t(), ExStreamClient.Model.MessageActionRequest.t()) ::
           {:ok, ExStreamClient.Model.MessageResponse.t()} | {:error, any()}
   def run_message_action(id, payload) do
@@ -228,13 +229,13 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Queries history for one message
+  @doc ~S"""
+  Queries history for one message
 
-	
-	### Required Arguments:
-		- `payload`: QueryMessageHistoryRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryMessageHistoryRequest`
+  """
   @spec query_message_history(ExStreamClient.Model.QueryMessageHistoryRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryMessageHistoryResponse.t()} | {:error, any()}
   def query_message_history(payload) do
@@ -274,18 +275,18 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Cast a vote on a poll
+  @doc ~S"""
+  Cast a vote on a poll
 
-Sends events:
-- poll.vote_casted
+  ### Sends events:
+  - `poll.vote_casted`
 
-	
-	### Required Arguments:
-		- `message_id`
-		- `poll_id`
-		- `payload`: CastPollVoteRequest
-	"
+
+  ### Required Arguments:
+  - `message_id`
+  - `poll_id`
+  - `payload`: `Elixir.ExStreamClient.Model.CastPollVoteRequest`
+  """
   @spec cast_poll_vote(String.t(), String.t(), ExStreamClient.Model.CastPollVoteRequest.t()) ::
           {:ok, ExStreamClient.Model.PollVoteResponse.t()} | {:error, any()}
   def cast_poll_vote(message_id, poll_id, payload) do
@@ -329,14 +330,14 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Get reactions on a message
+  @doc ~S"""
+  Get reactions on a message
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: QueryReactionsRequest
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.QueryReactionsRequest`
+  """
   @spec query_reactions(String.t(), ExStreamClient.Model.QueryReactionsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryReactionsResponse.t()} | {:error, any()}
   def query_reactions(id, payload) do
@@ -376,16 +377,16 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Returns list of reactions of specific message
+  @doc ~S"""
+  Returns list of reactions of specific message
 
-	
-	### Required Arguments:
-		- `id`
-	### Optional Arguments:
-		- `limit`
-		- `offset`
-	"
+
+  ### Required Arguments:
+  - `id`
+  ### Optional Arguments:
+  - `limit`
+  - `offset`
+  """
   @spec get_reactions(String.t()) ::
           {:ok, ExStreamClient.Model.GetReactionsResponse.t()} | {:error, any()}
   @spec get_reactions(String.t(), [{:offset, integer()} | {:limit, integer()}]) ::
@@ -433,27 +434,27 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Returns replies (thread) of the message
+  @doc ~S"""
+  Returns replies (thread) of the message
 
-	
-	### Required Arguments:
-		- `parent_id`
-	### Optional Arguments:
-		- `sort`
-		- `limit`
-		- `offset`
-		- `id_gte`
-		- `id_gt`
-		- `id_lte`
-		- `id_lt`
-		- `created_at_after_or_equal`
-		- `created_at_after`
-		- `created_at_before_or_equal`
-		- `created_at_before`
-		- `id_around`
-		- `created_at_around`
-	"
+
+  ### Required Arguments:
+  - `parent_id`
+  ### Optional Arguments:
+  - `sort`
+  - `limit`
+  - `offset`
+  - `id_gte`
+  - `id_gt`
+  - `id_lte`
+  - `id_lt`
+  - `created_at_after_or_equal`
+  - `created_at_after`
+  - `created_at_before_or_equal`
+  - `created_at_before`
+  - `id_around`
+  - `created_at_around`
+  """
   @spec get_replies(String.t()) ::
           {:ok, ExStreamClient.Model.GetRepliesResponse.t()} | {:error, any()}
   @spec get_replies(String.t(), [
@@ -531,18 +532,18 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Undelete a message that was previously soft-deleted
+  @doc ~S"""
+  Undelete a message that was previously soft-deleted
 
-Sends events:
-- message.undeleted
-- message.undeleted
+  ### Sends events:
+  - `message.undeleted`
+  - `message.undeleted`
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: UpdateMessageRequest
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateMessageRequest`
+  """
   @spec undelete_message(String.t(), ExStreamClient.Model.UpdateMessageRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateMessageResponse.t()} | {:error, any()}
   def undelete_message(id, payload) do
@@ -582,18 +583,18 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Translates message to a given language using automated translation software
+  @doc ~S"""
+  Translates message to a given language using automated translation software
 
-Sends events:
-- message.updated
-- message.updated
+  ### Sends events:
+  - `message.updated`
+  - `message.updated`
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: TranslateMessageRequest
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.TranslateMessageRequest`
+  """
   @spec translate_message(String.t(), ExStreamClient.Model.TranslateMessageRequest.t()) ::
           {:ok, ExStreamClient.Model.MessageResponse.t()} | {:error, any()}
   def translate_message(id, payload) do
@@ -633,20 +634,20 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Commits a pending message, which will make it visible in the channel
+  @doc ~S"""
+  Commits a pending message, which will make it visible in the channel
 
-Sends events:
-- message.new
-- message.updated
-- message.new
-- message.updated
+  ### Sends events:
+  - `message.new`
+  - `message.updated`
+  - `message.new`
+  - `message.updated`
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: CommitMessageRequest
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.CommitMessageRequest`
+  """
   @spec commit_message(String.t(), ExStreamClient.Model.CommitMessageRequest.t()) ::
           {:ok, ExStreamClient.Model.MessageResponse.t()} | {:error, any()}
   def commit_message(id, payload) do
@@ -686,18 +687,18 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Updates certain fields of the message
+  @doc ~S"""
+  Updates certain fields of the message
 
-Sends events:
-- message.updated
-- message.updated
+  ### Sends events:
+  - `message.updated`
+  - `message.updated`
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: UpdateMessagePartialRequest
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateMessagePartialRequest`
+  """
   @spec update_message_partial(String.t(), ExStreamClient.Model.UpdateMessagePartialRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateMessagePartialResponse.t()} | {:error, any()}
   def update_message_partial(id, payload) do
@@ -737,18 +738,18 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Updates message with new data
+  @doc ~S"""
+  Updates message with new data
 
-Sends events:
-- message.updated
-- message.updated
+  ### Sends events:
+  - `message.updated`
+  - `message.updated`
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: UpdateMessageRequest
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateMessageRequest`
+  """
   @spec update_message(String.t(), ExStreamClient.Model.UpdateMessageRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateMessageResponse.t()} | {:error, any()}
   def update_message(id, payload) do
@@ -788,15 +789,15 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Returns message by ID
+  @doc ~S"""
+  Returns message by ID
 
-	
-	### Required Arguments:
-		- `id`
-	### Optional Arguments:
-		- `show_deleted_message`
-	"
+
+  ### Required Arguments:
+  - `id`
+  ### Optional Arguments:
+  - `show_deleted_message`
+  """
   @spec get_message(String.t()) ::
           {:ok, ExStreamClient.Model.GetMessageResponse.t()} | {:error, any()}
   @spec get_message(String.t(), show_deleted_message: boolean()) ::
@@ -844,20 +845,20 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Deletes message
+  @doc ~S"""
+  Deletes message
 
-Sends events:
-- message.deleted
-- message.deleted
+  ### Sends events:
+  - `message.deleted`
+  - `message.deleted`
 
-	
-	### Required Arguments:
-		- `id`
-	### Optional Arguments:
-		- `hard`
-		- `deleted_by`
-	"
+
+  ### Required Arguments:
+  - `id`
+  ### Optional Arguments:
+  - `hard`
+  - `deleted_by`
+  """
   @spec delete_message(String.t()) ::
           {:ok, ExStreamClient.Model.DeleteMessageResponse.t()} | {:error, any()}
   @spec delete_message(String.t(), [{:deleted_by, String.t()} | {:hard, boolean()}]) ::

--- a/lib/ex_stream_client/operations/chat/moderation.ex
+++ b/lib/ex_stream_client/operations/chat/moderation.ex
@@ -1,19 +1,18 @@
 defmodule ExStreamClient.Operations.Chat.Moderation do
-  @moduledoc "
-	Modules for interacting with the `chat/moderation` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/moderation` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Find and filter message flags
 
-	
-	### Required Arguments:
-		
-	### Optional Arguments:
-		- `payload`: QueryMessageFlagsPayload
-	"
+  @doc ~S"""
+  Find and filter message flags
+
+
+  ### Optional Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryMessageFlagsPayload`
+  """
   @spec query_message_flags() ::
           {:ok, ExStreamClient.Model.QueryMessageFlagsResponse.t()} | {:error, any()}
   @spec query_message_flags(payload: ExStreamClient.Model.QueryMessageFlagsPayload.t()) ::
@@ -61,17 +60,17 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
     end
   end
 
-  @doc ~S"
-	Unmutes channel for user
+  @doc ~S"""
+  Unmutes channel for user
 
-Sends events:
-- channel.unmuted
-- channel.unmuted
+  ### Sends events:
+  - `channel.unmuted`
+  - `channel.unmuted`
 
-	
-	### Required Arguments:
-		- `payload`: UnmuteChannelRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UnmuteChannelRequest`
+  """
   @spec unmute_channel(ExStreamClient.Model.UnmuteChannelRequest.t()) ::
           {:ok, ExStreamClient.Model.UnmuteResponse.t()} | {:error, any()}
   def unmute_channel(payload) do
@@ -112,17 +111,17 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Mutes channel for user
+  @doc ~S"""
+  Mutes channel for user
 
-Sends events:
-- channel.muted
-- channel.muted
+  ### Sends events:
+  - `channel.muted`
+  - `channel.muted`
 
-	
-	### Required Arguments:
-		- `payload`: MuteChannelRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.MuteChannelRequest`
+  """
   @spec mute_channel(ExStreamClient.Model.MuteChannelRequest.t()) ::
           {:ok, ExStreamClient.Model.MuteChannelResponse.t()} | {:error, any()}
   def mute_channel(payload) do

--- a/lib/ex_stream_client/operations/chat/polls.ex
+++ b/lib/ex_stream_client/operations/chat/polls.ex
@@ -1,20 +1,21 @@
 defmodule ExStreamClient.Operations.Chat.Polls do
-  @moduledoc "
-	Modules for interacting with the `chat/polls` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/polls` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Queries votes
 
-	
-	### Required Arguments:
-		- `poll_id`
-		- `payload`: QueryPollVotesRequest
-	### Optional Arguments:
-		- `user_id`
-	"
+  @doc ~S"""
+  Queries votes
+
+
+  ### Required Arguments:
+  - `poll_id`
+  - `payload`: `Elixir.ExStreamClient.Model.QueryPollVotesRequest`
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec query_poll_votes(String.t(), ExStreamClient.Model.QueryPollVotesRequest.t()) ::
           {:ok, ExStreamClient.Model.PollVotesResponse.t()} | {:error, any()}
   @spec query_poll_votes(String.t(), ExStreamClient.Model.QueryPollVotesRequest.t(),
@@ -63,17 +64,17 @@ defmodule ExStreamClient.Operations.Chat.Polls do
     end
   end
 
-  @doc ~S"
-	Updates a poll
+  @doc ~S"""
+  Updates a poll
 
-Sends events:
-- poll.closed
-- poll.updated
+  ### Sends events:
+  - `poll.closed`
+  - `poll.updated`
 
-	
-	### Required Arguments:
-		- `payload`: UpdatePollRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UpdatePollRequest`
+  """
   @spec update_poll(ExStreamClient.Model.UpdatePollRequest.t()) ::
           {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
   def update_poll(payload) do
@@ -112,13 +113,13 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Creates a new poll
+  @doc ~S"""
+  Creates a new poll
 
-	
-	### Required Arguments:
-		- `payload`: CreatePollRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CreatePollRequest`
+  """
   @spec create_poll(ExStreamClient.Model.CreatePollRequest.t()) ::
           {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
   def create_poll(payload) do
@@ -157,17 +158,17 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Updates a poll option
+  @doc ~S"""
+  Updates a poll option
 
-Sends events:
-- poll.updated
+  ### Sends events:
+  - `poll.updated`
 
-	
-	### Required Arguments:
-		- `poll_id`
-		- `payload`: UpdatePollOptionRequest
-	"
+
+  ### Required Arguments:
+  - `poll_id`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdatePollOptionRequest`
+  """
   @spec update_poll_option(String.t(), ExStreamClient.Model.UpdatePollOptionRequest.t()) ::
           {:ok, ExStreamClient.Model.PollOptionResponse.t()} | {:error, any()}
   def update_poll_option(poll_id, payload) do
@@ -207,17 +208,17 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Creates a poll option
+  @doc ~S"""
+  Creates a poll option
 
-Sends events:
-- poll.updated
+  ### Sends events:
+  - `poll.updated`
 
-	
-	### Required Arguments:
-		- `poll_id`
-		- `payload`: CreatePollOptionRequest
-	"
+
+  ### Required Arguments:
+  - `poll_id`
+  - `payload`: `Elixir.ExStreamClient.Model.CreatePollOptionRequest`
+  """
   @spec create_poll_option(String.t(), ExStreamClient.Model.CreatePollOptionRequest.t()) ::
           {:ok, ExStreamClient.Model.PollOptionResponse.t()} | {:error, any()}
   def create_poll_option(poll_id, payload) do
@@ -257,17 +258,17 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Updates a poll partially
+  @doc ~S"""
+  Updates a poll partially
 
-Sends events:
-- poll.updated
+  ### Sends events:
+  - `poll.updated`
 
-	
-	### Required Arguments:
-		- `poll_id`
-		- `payload`: UpdatePollPartialRequest
-	"
+
+  ### Required Arguments:
+  - `poll_id`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdatePollPartialRequest`
+  """
   @spec update_poll_partial(String.t(), ExStreamClient.Model.UpdatePollPartialRequest.t()) ::
           {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
   def update_poll_partial(poll_id, payload) do
@@ -307,15 +308,15 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Retrieves a poll
+  @doc ~S"""
+  Retrieves a poll
 
-	
-	### Required Arguments:
-		- `poll_id`
-	### Optional Arguments:
-		- `user_id`
-	"
+
+  ### Required Arguments:
+  - `poll_id`
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec get_poll(String.t()) :: {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
   @spec get_poll(String.t(), user_id: String.t()) ::
           {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
@@ -362,18 +363,18 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Deletes a poll
+  @doc ~S"""
+  Deletes a poll
 
-Sends events:
-- poll.deleted
+  ### Sends events:
+  - `poll.deleted`
 
-	
-	### Required Arguments:
-		- `poll_id`
-	### Optional Arguments:
-		- `user_id`
-	"
+
+  ### Required Arguments:
+  - `poll_id`
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec delete_poll(String.t()) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_poll(String.t(), user_id: String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
@@ -420,15 +421,15 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Queries polls
+  @doc ~S"""
+  Queries polls
 
-	
-	### Required Arguments:
-		- `payload`: QueryPollsRequest
-	### Optional Arguments:
-		- `user_id`
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryPollsRequest`
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec query_polls(ExStreamClient.Model.QueryPollsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryPollsResponse.t()} | {:error, any()}
   @spec query_polls(ExStreamClient.Model.QueryPollsRequest.t(), user_id: String.t()) ::
@@ -476,16 +477,16 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Retrieves a poll option
+  @doc ~S"""
+  Retrieves a poll option
 
-	
-	### Required Arguments:
-		- `poll_id`
-		- `option_id`
-	### Optional Arguments:
-		- `user_id`
-	"
+
+  ### Required Arguments:
+  - `poll_id`
+  - `option_id`
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec get_poll_option(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.PollOptionResponse.t()} | {:error, any()}
   @spec get_poll_option(String.t(), String.t(), user_id: String.t()) ::
@@ -533,19 +534,19 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Deletes a poll option
+  @doc ~S"""
+  Deletes a poll option
 
-Sends events:
-- poll.updated
+  ### Sends events:
+  - `poll.updated`
 
-	
-	### Required Arguments:
-		- `poll_id`
-		- `option_id`
-	### Optional Arguments:
-		- `user_id`
-	"
+
+  ### Required Arguments:
+  - `poll_id`
+  - `option_id`
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec delete_poll_option(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_poll_option(String.t(), String.t(), user_id: String.t()) ::

--- a/lib/ex_stream_client/operations/chat/push_preferences.ex
+++ b/lib/ex_stream_client/operations/chat/push_preferences.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Chat.PushPreferences do
-  @moduledoc "
-	Modules for interacting with the `chat/push_preferences` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/push_preferences` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Update the push preferences for a user and or channel member. Set to all, mentions or none
 
-	
-	### Required Arguments:
-		- `payload`: UpsertPushPreferencesRequest
-	"
+  @doc ~S"""
+  Update the push preferences for a user and or channel member. Set to all, mentions or none
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UpsertPushPreferencesRequest`
+  """
   @spec update_push_notification_preferences(
           ExStreamClient.Model.UpsertPushPreferencesRequest.t()
         ) :: {:ok, ExStreamClient.Model.UpsertPushPreferencesResponse.t()} | {:error, any()}

--- a/lib/ex_stream_client/operations/chat/push_templates.ex
+++ b/lib/ex_stream_client/operations/chat/push_templates.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Chat.PushTemplates do
-  @moduledoc "
-	Modules for interacting with the `chat/push_templates` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/push_templates` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Create or update a push notification template for a specific event type and push provider
 
-	
-	### Required Arguments:
-		- `payload`: UpsertPushTemplateRequest
-	"
+  @doc ~S"""
+  Create or update a push notification template for a specific event type and push provider
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UpsertPushTemplateRequest`
+  """
   @spec upsert_push_template(ExStreamClient.Model.UpsertPushTemplateRequest.t()) ::
           {:ok, ExStreamClient.Model.UpsertPushTemplateResponse.t()} | {:error, any()}
   def upsert_push_template(payload) do
@@ -51,15 +52,15 @@ defmodule ExStreamClient.Operations.Chat.PushTemplates do
     end
   end
 
-  @doc ~S"
-	Retrieve push notification templates for Chat.
+  @doc ~S"""
+  Retrieve push notification templates for Chat.
 
-	
-	### Required Arguments:
-		- `push_provider_type`
-	### Optional Arguments:
-		- `push_provider_name`
-	"
+
+  ### Required Arguments:
+  - `push_provider_type`
+  ### Optional Arguments:
+  - `push_provider_name`
+  """
   @spec get_push_templates(String.t()) ::
           {:ok, ExStreamClient.Model.GetPushTemplatesResponse.t()} | {:error, any()}
   @spec get_push_templates(String.t(), push_provider_name: String.t()) ::

--- a/lib/ex_stream_client/operations/chat/query_banned_users.ex
+++ b/lib/ex_stream_client/operations/chat/query_banned_users.ex
@@ -1,19 +1,18 @@
 defmodule ExStreamClient.Operations.Chat.QueryBannedUsers do
-  @moduledoc "
-	Modules for interacting with the `chat/query_banned_users` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/query_banned_users` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Find and filter channel scoped or global user bans
 
-	
-	### Required Arguments:
-		
-	### Optional Arguments:
-		- `payload`: QueryBannedUsersPayload
-	"
+  @doc ~S"""
+  Find and filter channel scoped or global user bans
+
+
+  ### Optional Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryBannedUsersPayload`
+  """
   @spec query_banned_users() ::
           {:ok, ExStreamClient.Model.QueryBannedUsersResponse.t()} | {:error, any()}
   @spec query_banned_users(payload: ExStreamClient.Model.QueryBannedUsersPayload.t()) ::

--- a/lib/ex_stream_client/operations/chat/search.ex
+++ b/lib/ex_stream_client/operations/chat/search.ex
@@ -1,19 +1,18 @@
 defmodule ExStreamClient.Operations.Chat.Search do
-  @moduledoc "
-	Modules for interacting with the `chat/search` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/search` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Search messages across channels
 
-	
-	### Required Arguments:
-		
-	### Optional Arguments:
-		- `payload`: SearchPayload
-	"
+  @doc ~S"""
+  Search messages across channels
+
+
+  ### Optional Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.SearchPayload`
+  """
   @spec search() :: {:ok, ExStreamClient.Model.SearchResponse.t()} | {:error, any()}
   @spec search(payload: ExStreamClient.Model.SearchPayload.t()) ::
           {:ok, ExStreamClient.Model.SearchResponse.t()} | {:error, any()}

--- a/lib/ex_stream_client/operations/chat/segments.ex
+++ b/lib/ex_stream_client/operations/chat/segments.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Chat.Segments do
-  @moduledoc "
-	Modules for interacting with the `chat/segments` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/segments` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Get segment
 
-	
-	### Required Arguments:
-		- `id`
-	"
+  @doc ~S"""
+  Get segment
+
+
+  ### Required Arguments:
+  - `id`
+  """
   @spec get_segment(String.t()) ::
           {:ok, ExStreamClient.Model.GetSegmentResponse.t()} | {:error, any()}
   def get_segment(id) do
@@ -50,13 +51,13 @@ defmodule ExStreamClient.Operations.Chat.Segments do
     end
   end
 
-  @doc ~S"
-	Delete a segment
+  @doc ~S"""
+  Delete a segment
 
-	
-	### Required Arguments:
-		- `id`
-	"
+
+  ### Required Arguments:
+  - `id`
+  """
   @spec delete_segment(String.t()) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_segment(id) do
     request_opts = [url: "/api/v2/chat/segments/#{id}", method: :delete, params: []] ++ []
@@ -94,14 +95,14 @@ defmodule ExStreamClient.Operations.Chat.Segments do
     end
   end
 
-  @doc ~S"
-	Query segment targets
+  @doc ~S"""
+  Query segment targets
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: QuerySegmentTargetsRequest
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.QuerySegmentTargetsRequest`
+  """
   @spec query_segment_targets(String.t(), ExStreamClient.Model.QuerySegmentTargetsRequest.t()) ::
           {:ok, ExStreamClient.Model.QuerySegmentTargetsResponse.t()} | {:error, any()}
   def query_segment_targets(id, payload) do
@@ -142,13 +143,13 @@ defmodule ExStreamClient.Operations.Chat.Segments do
     end
   end
 
-  @doc ~S"
-	Query segments
+  @doc ~S"""
+  Query segments
 
-	
-	### Required Arguments:
-		- `payload`: QuerySegmentsRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QuerySegmentsRequest`
+  """
   @spec query_segments(ExStreamClient.Model.QuerySegmentsRequest.t()) ::
           {:ok, ExStreamClient.Model.QuerySegmentsResponse.t()} | {:error, any()}
   def query_segments(payload) do
@@ -188,14 +189,14 @@ defmodule ExStreamClient.Operations.Chat.Segments do
     end
   end
 
-  @doc ~S"
-	Delete targets from a segment
+  @doc ~S"""
+  Delete targets from a segment
 
-	
-	### Required Arguments:
-		- `id`
-		- `payload`: DeleteSegmentTargetsRequest
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `payload`: `Elixir.ExStreamClient.Model.DeleteSegmentTargetsRequest`
+  """
   @spec delete_segment_targets(String.t(), ExStreamClient.Model.DeleteSegmentTargetsRequest.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_segment_targets(id, payload) do
@@ -236,14 +237,14 @@ defmodule ExStreamClient.Operations.Chat.Segments do
     end
   end
 
-  @doc ~S"
-	Check whether a target exists in a segment. Returns 200 if the target exists, 404 otherwise
+  @doc ~S"""
+  Check whether a target exists in a segment. Returns 200 if the target exists, 404 otherwise
 
-	
-	### Required Arguments:
-		- `id`
-		- `target_id`
-	"
+
+  ### Required Arguments:
+  - `id`
+  - `target_id`
+  """
   @spec segment_target_exists(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def segment_target_exists(id, target_id) do

--- a/lib/ex_stream_client/operations/chat/threads.ex
+++ b/lib/ex_stream_client/operations/chat/threads.ex
@@ -1,22 +1,23 @@
 defmodule ExStreamClient.Operations.Chat.Threads do
-  @moduledoc "
-	Modules for interacting with the `chat/threads` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/threads` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Updates certain fields of the thread
 
-Sends events:
-- thread.updated
-- thread.updated
+  @doc ~S"""
+  Updates certain fields of the thread
 
-	
-	### Required Arguments:
-		- `message_id`
-		- `payload`: UpdateThreadPartialRequest
-	"
+  ### Sends events:
+  - `thread.updated`
+  - `thread.updated`
+
+
+  ### Required Arguments:
+  - `message_id`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateThreadPartialRequest`
+  """
   @spec update_thread_partial(String.t(), ExStreamClient.Model.UpdateThreadPartialRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateThreadPartialResponse.t()} | {:error, any()}
   def update_thread_partial(message_id, payload) do
@@ -56,17 +57,17 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Return a specific thread
+  @doc ~S"""
+  Return a specific thread
 
-	
-	### Required Arguments:
-		- `message_id`
-	### Optional Arguments:
-		- `reply_limit`
-		- `participant_limit`
-		- `member_limit`
-	"
+
+  ### Required Arguments:
+  - `message_id`
+  ### Optional Arguments:
+  - `reply_limit`
+  - `participant_limit`
+  - `member_limit`
+  """
   @spec get_thread(String.t()) ::
           {:ok, ExStreamClient.Model.GetThreadResponse.t()} | {:error, any()}
   @spec get_thread(String.t(), [
@@ -115,13 +116,13 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Returns the list of threads for specific user
+  @doc ~S"""
+  Returns the list of threads for specific user
 
-	
-	### Required Arguments:
-		- `payload`: QueryThreadsRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryThreadsRequest`
+  """
   @spec query_threads(ExStreamClient.Model.QueryThreadsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryThreadsResponse.t()} | {:error, any()}
   def query_threads(payload) do

--- a/lib/ex_stream_client/operations/chat/unread.ex
+++ b/lib/ex_stream_client/operations/chat/unread.ex
@@ -1,17 +1,16 @@
 defmodule ExStreamClient.Operations.Chat.Unread do
-  @moduledoc "
-	Modules for interacting with the `chat/unread` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/unread` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Fetch unread counts for a single user
 
-	
-	### Required Arguments:
-		
-	"
+  @doc ~S"""
+  Fetch unread counts for a single user
+
+
+  """
   @spec unread_counts() ::
           {:ok, ExStreamClient.Model.WrappedUnreadCountsResponse.t()} | {:error, any()}
   def unread_counts() do

--- a/lib/ex_stream_client/operations/chat/unread_batch.ex
+++ b/lib/ex_stream_client/operations/chat/unread_batch.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Chat.UnreadBatch do
-  @moduledoc "
-	Modules for interacting with the `chat/unread_batch` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/unread_batch` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Fetch unread counts in batch for multiple users in one call
 
-	
-	### Required Arguments:
-		- `payload`: UnreadCountsBatchRequest
-	"
+  @doc ~S"""
+  Fetch unread counts in batch for multiple users in one call
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UnreadCountsBatchRequest`
+  """
   @spec unread_counts_batch(ExStreamClient.Model.UnreadCountsBatchRequest.t()) ::
           {:ok, ExStreamClient.Model.UnreadCountsBatchResponse.t()} | {:error, any()}
   def unread_counts_batch(payload) do

--- a/lib/ex_stream_client/operations/chat/users.ex
+++ b/lib/ex_stream_client/operations/chat/users.ex
@@ -1,21 +1,22 @@
 defmodule ExStreamClient.Operations.Chat.Users do
-  @moduledoc "
-	Modules for interacting with the `chat/users` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `chat/users` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Sends a custom event to a user
 
-Sends events:
-- *
+  @doc ~S"""
+  Sends a custom event to a user
 
-	
-	### Required Arguments:
-		- `user_id`
-		- `payload`: SendUserCustomEventRequest
-	"
+  ### Sends events:
+  - `*`
+
+
+  ### Required Arguments:
+  - `user_id`
+  - `payload`: `Elixir.ExStreamClient.Model.SendUserCustomEventRequest`
+  """
   @spec send_user_custom_event(String.t(), ExStreamClient.Model.SendUserCustomEventRequest.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def send_user_custom_event(user_id, payload) do

--- a/lib/ex_stream_client/operations/check_push.ex
+++ b/lib/ex_stream_client/operations/check_push.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.CheckPush do
-  @moduledoc "
-	Modules for interacting with the `check_push` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `check_push` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Sends a test message via push, this is a test endpoint to verify your push settings
 
-	
-	### Required Arguments:
-		- `payload`: CheckPushRequest
-	"
+  @doc ~S"""
+  Sends a test message via push, this is a test endpoint to verify your push settings
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CheckPushRequest`
+  """
   @spec check_push(ExStreamClient.Model.CheckPushRequest.t()) ::
           {:ok, ExStreamClient.Model.CheckPushResponse.t()} | {:error, any()}
   def check_push(payload) do

--- a/lib/ex_stream_client/operations/check_sns.ex
+++ b/lib/ex_stream_client/operations/check_sns.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.CheckSns do
-  @moduledoc "
-	Modules for interacting with the `check_sns` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `check_sns` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Validates Amazon SNS configuration
 
-	
-	### Required Arguments:
-		- `payload`: CheckSNSRequest
-	"
+  @doc ~S"""
+  Validates Amazon SNS configuration
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CheckSNSRequest`
+  """
   @spec check_sns(ExStreamClient.Model.CheckSNSRequest.t()) ::
           {:ok, ExStreamClient.Model.CheckSNSResponse.t()} | {:error, any()}
   def check_sns(payload) do

--- a/lib/ex_stream_client/operations/check_sqs.ex
+++ b/lib/ex_stream_client/operations/check_sqs.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.CheckSqs do
-  @moduledoc "
-	Modules for interacting with the `check_sqs` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `check_sqs` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Validates Amazon SQS credentials
 
-	
-	### Required Arguments:
-		- `payload`: CheckSQSRequest
-	"
+  @doc ~S"""
+  Validates Amazon SQS credentials
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CheckSQSRequest`
+  """
   @spec check_sqs(ExStreamClient.Model.CheckSQSRequest.t()) ::
           {:ok, ExStreamClient.Model.CheckSQSResponse.t()} | {:error, any()}
   def check_sqs(payload) do

--- a/lib/ex_stream_client/operations/devices.ex
+++ b/lib/ex_stream_client/operations/devices.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Devices do
-  @moduledoc "
-	Modules for interacting with the `devices` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `devices` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Adds a new device to a user, if the same device already exists the call will have no effect
 
-	
-	### Required Arguments:
-		- `payload`: CreateDeviceRequest
-	"
+  @doc ~S"""
+  Adds a new device to a user, if the same device already exists the call will have no effect
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CreateDeviceRequest`
+  """
   @spec create_device(ExStreamClient.Model.CreateDeviceRequest.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def create_device(payload) do
@@ -50,15 +51,13 @@ defmodule ExStreamClient.Operations.Devices do
     end
   end
 
-  @doc ~S"
-	Returns all available devices
+  @doc ~S"""
+  Returns all available devices
 
-	
-	### Required Arguments:
-		
-	### Optional Arguments:
-		- `user_id`
-	"
+
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec list_devices() :: {:ok, ExStreamClient.Model.ListDevicesResponse.t()} | {:error, any()}
   @spec list_devices(user_id: String.t()) ::
           {:ok, ExStreamClient.Model.ListDevicesResponse.t()} | {:error, any()}
@@ -105,15 +104,15 @@ defmodule ExStreamClient.Operations.Devices do
     end
   end
 
-  @doc ~S"
-	Deletes one device
+  @doc ~S"""
+  Deletes one device
 
-	
-	### Required Arguments:
-		- `id`
-	### Optional Arguments:
-		- `user_id`
-	"
+
+  ### Required Arguments:
+  - `id`
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec delete_device(String.t()) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_device(String.t(), user_id: String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}

--- a/lib/ex_stream_client/operations/export.ex
+++ b/lib/ex_stream_client/operations/export.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Export do
-  @moduledoc "
-	Modules for interacting with the `export` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `export` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Exports user profile, reactions and messages for list of given users
 
-	
-	### Required Arguments:
-		- `payload`: ExportUsersRequest
-	"
+  @doc ~S"""
+  Exports user profile, reactions and messages for list of given users
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.ExportUsersRequest`
+  """
   @spec export_users(ExStreamClient.Model.ExportUsersRequest.t()) ::
           {:ok, ExStreamClient.Model.ExportUsersResponse.t()} | {:error, any()}
   def export_users(payload) do

--- a/lib/ex_stream_client/operations/external_storage.ex
+++ b/lib/ex_stream_client/operations/external_storage.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.ExternalStorage do
-  @moduledoc "
-	Modules for interacting with the `external_storage` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `external_storage` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	
 
-	
-	### Required Arguments:
-		- `name`
-	"
+  @doc ~S"""
+
+
+
+  ### Required Arguments:
+  - `name`
+  """
   @spec check_external_storage(String.t()) ::
           {:ok, ExStreamClient.Model.CheckExternalStorageResponse.t()} | {:error, any()}
   def check_external_storage(name) do
@@ -50,13 +51,13 @@ defmodule ExStreamClient.Operations.ExternalStorage do
     end
   end
 
-  @doc ~S"
-	Creates new external storage
+  @doc ~S"""
+  Creates new external storage
 
-	
-	### Required Arguments:
-		- `payload`: CreateExternalStorageRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CreateExternalStorageRequest`
+  """
   @spec create_external_storage(ExStreamClient.Model.CreateExternalStorageRequest.t()) ::
           {:ok, ExStreamClient.Model.CreateExternalStorageResponse.t()} | {:error, any()}
   def create_external_storage(payload) do
@@ -95,13 +96,11 @@ defmodule ExStreamClient.Operations.ExternalStorage do
     end
   end
 
-  @doc ~S"
-	Lists external storage
+  @doc ~S"""
+  Lists external storage
 
-	
-	### Required Arguments:
-		
-	"
+
+  """
   @spec list_external_storage() ::
           {:ok, ExStreamClient.Model.ListExternalStorageResponse.t()} | {:error, any()}
   def list_external_storage() do
@@ -140,14 +139,14 @@ defmodule ExStreamClient.Operations.ExternalStorage do
     end
   end
 
-  @doc ~S"
-	
+  @doc ~S"""
 
-	
-	### Required Arguments:
-		- `name`
-		- `payload`: UpdateExternalStorageRequest
-	"
+
+
+  ### Required Arguments:
+  - `name`
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateExternalStorageRequest`
+  """
   @spec update_external_storage(String.t(), ExStreamClient.Model.UpdateExternalStorageRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateExternalStorageResponse.t()} | {:error, any()}
   def update_external_storage(name, payload) do
@@ -187,13 +186,13 @@ defmodule ExStreamClient.Operations.ExternalStorage do
     end
   end
 
-  @doc ~S"
-	Deletes external storage
+  @doc ~S"""
+  Deletes external storage
 
-	
-	### Required Arguments:
-		- `name`
-	"
+
+  ### Required Arguments:
+  - `name`
+  """
   @spec delete_external_storage(String.t()) ::
           {:ok, ExStreamClient.Model.DeleteExternalStorageResponse.t()} | {:error, any()}
   def delete_external_storage(name) do

--- a/lib/ex_stream_client/operations/guest.ex
+++ b/lib/ex_stream_client/operations/guest.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Guest do
-  @moduledoc "
-	Modules for interacting with the `guest` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `guest` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	
 
-	
-	### Required Arguments:
-		- `payload`: CreateGuestRequest
-	"
+  @doc ~S"""
+
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CreateGuestRequest`
+  """
   @spec create_guest(ExStreamClient.Model.CreateGuestRequest.t()) ::
           {:ok, ExStreamClient.Model.CreateGuestResponse.t()} | {:error, any()}
   def create_guest(payload) do

--- a/lib/ex_stream_client/operations/import_urls.ex
+++ b/lib/ex_stream_client/operations/import_urls.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.ImportUrls do
-  @moduledoc "
-	Modules for interacting with the `import_urls` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `import_urls` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Creates a new import URL
 
-	
-	### Required Arguments:
-		- `payload`: CreateImportURLRequest
-	"
+  @doc ~S"""
+  Creates a new import URL
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CreateImportURLRequest`
+  """
   @spec create_import_url(ExStreamClient.Model.CreateImportURLRequest.t()) ::
           {:ok, ExStreamClient.Model.CreateImportURLResponse.t()} | {:error, any()}
   def create_import_url(payload) do

--- a/lib/ex_stream_client/operations/imports.ex
+++ b/lib/ex_stream_client/operations/imports.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Imports do
-  @moduledoc "
-	Modules for interacting with the `imports` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `imports` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Gets an import
 
-	
-	### Required Arguments:
-		- `id`
-	"
+  @doc ~S"""
+  Gets an import
+
+
+  ### Required Arguments:
+  - `id`
+  """
   @spec get_import(String.t()) ::
           {:ok, ExStreamClient.Model.GetImportResponse.t()} | {:error, any()}
   def get_import(id) do
@@ -50,13 +51,13 @@ defmodule ExStreamClient.Operations.Imports do
     end
   end
 
-  @doc ~S"
-	Creates a new import
+  @doc ~S"""
+  Creates a new import
 
-	
-	### Required Arguments:
-		- `payload`: CreateImportRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CreateImportRequest`
+  """
   @spec create_import(ExStreamClient.Model.CreateImportRequest.t()) ::
           {:ok, ExStreamClient.Model.CreateImportResponse.t()} | {:error, any()}
   def create_import(payload) do
@@ -95,13 +96,11 @@ defmodule ExStreamClient.Operations.Imports do
     end
   end
 
-  @doc ~S"
-	Gets an import
+  @doc ~S"""
+  Gets an import
 
-	
-	### Required Arguments:
-		
-	"
+
+  """
   @spec list_imports() :: {:ok, ExStreamClient.Model.ListImportsResponse.t()} | {:error, any()}
   def list_imports() do
     request_opts = [url: "/api/v2/imports", method: :get, params: []] ++ []

--- a/lib/ex_stream_client/operations/moderation.ex
+++ b/lib/ex_stream_client/operations/moderation.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Moderation do
-  @moduledoc "
-	Modules for interacting with the `moderation` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `moderation` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Custom check, add your own AI model reports to the review queue
 
-	
-	### Required Arguments:
-		- `payload`: CustomCheckRequest
-	"
+  @doc ~S"""
+  Custom check, add your own AI model reports to the review queue
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CustomCheckRequest`
+  """
   @spec custom_check(ExStreamClient.Model.CustomCheckRequest.t()) ::
           {:ok, ExStreamClient.Model.CustomCheckResponse.t()} | {:error, any()}
   def custom_check(payload) do
@@ -51,17 +52,17 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Unban a user from a channel or globally.
+  @doc ~S"""
+  Unban a user from a channel or globally.
 
-	
-	### Required Arguments:
-		- `target_user_id`
-		- `payload`: UnbanRequest
-	### Optional Arguments:
-		- `channel_cid`
-		- `created_by`
-	"
+
+  ### Required Arguments:
+  - `target_user_id`
+  - `payload`: `Elixir.ExStreamClient.Model.UnbanRequest`
+  ### Optional Arguments:
+  - `channel_cid`
+  - `created_by`
+  """
   @spec unban(String.t(), ExStreamClient.Model.UnbanRequest.t()) ::
           {:ok, ExStreamClient.Model.UnbanResponse.t()} | {:error, any()}
   @spec unban(String.t(), ExStreamClient.Model.UnbanRequest.t(), [
@@ -113,13 +114,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Take action on flagged content, such as marking content as safe, deleting content, banning users, or executing custom moderation actions. Supports various action types with configurable parameters.
+  @doc ~S"""
+  Take action on flagged content, such as marking content as safe, deleting content, banning users, or executing custom moderation actions. Supports various action types with configurable parameters.
 
-	
-	### Required Arguments:
-		- `payload`: SubmitActionRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.SubmitActionRequest`
+  """
   @spec submit_action(ExStreamClient.Model.SubmitActionRequest.t()) ::
           {:ok, ExStreamClient.Model.SubmitActionResponse.t()} | {:error, any()}
   def submit_action(payload) do
@@ -159,13 +160,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Unmute a user
+  @doc ~S"""
+  Unmute a user
 
-	
-	### Required Arguments:
-		- `payload`: UnmuteRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UnmuteRequest`
+  """
   @spec unmute(ExStreamClient.Model.UnmuteRequest.t()) ::
           {:ok, ExStreamClient.Model.UnmuteResponse.t()} | {:error, any()}
   def unmute(payload) do
@@ -205,13 +206,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Search and filter moderation configurations across your application. This endpoint is designed for building moderation dashboards and managing multiple configuration sets.
+  @doc ~S"""
+  Search and filter moderation configurations across your application. This endpoint is designed for building moderation dashboards and managing multiple configuration sets.
 
-	
-	### Required Arguments:
-		- `payload`: QueryModerationConfigsRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryModerationConfigsRequest`
+  """
   @spec query_moderation_configs(ExStreamClient.Model.QueryModerationConfigsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryModerationConfigsResponse.t()} | {:error, any()}
   def query_moderation_configs(payload) do
@@ -251,13 +252,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Retrieve a specific review queue item by its ID
+  @doc ~S"""
+  Retrieve a specific review queue item by its ID
 
-	
-	### Required Arguments:
-		- `id`
-	"
+
+  ### Required Arguments:
+  - `id`
+  """
   @spec get_review_queue_item(String.t()) ::
           {:ok, ExStreamClient.Model.GetReviewQueueItemResponse.t()} | {:error, any()}
   def get_review_queue_item(id) do
@@ -296,13 +297,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Moderate multiple images in bulk using a CSV file
+  @doc ~S"""
+  Moderate multiple images in bulk using a CSV file
 
-	
-	### Required Arguments:
-		- `payload`: BulkImageModerationRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.BulkImageModerationRequest`
+  """
   @spec bulk_image_moderation(ExStreamClient.Model.BulkImageModerationRequest.t()) ::
           {:ok, ExStreamClient.Model.BulkImageModerationResponse.t()} | {:error, any()}
   def bulk_image_moderation(payload) do
@@ -343,13 +344,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Search and filter moderation action logs with support for pagination. View the history of moderation actions taken, including who performed them and when.
+  @doc ~S"""
+  Search and filter moderation action logs with support for pagination. View the history of moderation actions taken, including who performed them and when.
 
-	
-	### Required Arguments:
-		- `payload`: QueryModerationLogsRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryModerationLogsRequest`
+  """
   @spec query_moderation_logs(ExStreamClient.Model.QueryModerationLogsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryModerationLogsResponse.t()} | {:error, any()}
   def query_moderation_logs(payload) do
@@ -388,13 +389,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Upsert feeds template for moderation
+  @doc ~S"""
+  Upsert feeds template for moderation
 
-	
-	### Required Arguments:
-		- `payload`: UpsertModerationTemplateRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UpsertModerationTemplateRequest`
+  """
   @spec v2_upsert_template(ExStreamClient.Model.UpsertModerationTemplateRequest.t()) ::
           {:ok, ExStreamClient.Model.UpsertModerationTemplateResponse.t()} | {:error, any()}
   def v2_upsert_template(payload) do
@@ -435,13 +436,11 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Retrieve a list of feed moderation templates that define preset moderation rules and configurations. Limited to 100 templates per request.
+  @doc ~S"""
+  Retrieve a list of feed moderation templates that define preset moderation rules and configurations. Limited to 100 templates per request.
 
-	
-	### Required Arguments:
-		
-	"
+
+  """
   @spec v2_query_templates() ::
           {:ok, ExStreamClient.Model.QueryFeedModerationTemplatesResponse.t()} | {:error, any()}
   def v2_query_templates() do
@@ -481,13 +480,11 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Delete a specific moderation template by its name
+  @doc ~S"""
+  Delete a specific moderation template by its name
 
-	
-	### Required Arguments:
-		
-	"
+
+  """
   @spec v2_delete_template() ::
           {:ok, ExStreamClient.Model.DeleteModerationTemplateResponse.t()} | {:error, any()}
   def v2_delete_template() do
@@ -527,13 +524,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Mute a user. Mutes are generally not visible to the user you mute, while block is something you notice.
+  @doc ~S"""
+  Mute a user. Mutes are generally not visible to the user you mute, while block is something you notice.
 
-	
-	### Required Arguments:
-		- `payload`: MuteRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.MuteRequest`
+  """
   @spec mute(ExStreamClient.Model.MuteRequest.t()) ::
           {:ok, ExStreamClient.Model.MuteResponse.t()} | {:error, any()}
   def mute(payload) do
@@ -572,13 +569,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Ban a user from a channel or the entire app
+  @doc ~S"""
+  Ban a user from a channel or the entire app
 
-	
-	### Required Arguments:
-		- `payload`: BanRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.BanRequest`
+  """
   @spec ban(ExStreamClient.Model.BanRequest.t()) ::
           {:ok, ExStreamClient.Model.BanResponse.t()} | {:error, any()}
   def ban(payload) do
@@ -617,13 +614,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Create a new moderation configuration or update an existing one. Configure settings for content filtering, AI analysis, toxicity detection, and other moderation features.
+  @doc ~S"""
+  Create a new moderation configuration or update an existing one. Configure settings for content filtering, AI analysis, toxicity detection, and other moderation features.
 
-	
-	### Required Arguments:
-		- `payload`: UpsertConfigRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UpsertConfigRequest`
+  """
   @spec upsert_config(ExStreamClient.Model.UpsertConfigRequest.t()) ::
           {:ok, ExStreamClient.Model.UpsertConfigResponse.t()} | {:error, any()}
   def upsert_config(payload) do
@@ -663,13 +660,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Query review queue items allows you to filter the review queue items. This is used for building a moderation dashboard.
+  @doc ~S"""
+  Query review queue items allows you to filter the review queue items. This is used for building a moderation dashboard.
 
-	
-	### Required Arguments:
-		- `payload`: QueryReviewQueueRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryReviewQueueRequest`
+  """
   @spec query_review_queue(ExStreamClient.Model.QueryReviewQueueRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryReviewQueueResponse.t()} | {:error, any()}
   def query_review_queue(payload) do
@@ -709,15 +706,15 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Retrieve a specific moderation configuration by its key and team. This configuration contains settings for various moderation features like toxicity detection, AI analysis, and filtering rules.
+  @doc ~S"""
+  Retrieve a specific moderation configuration by its key and team. This configuration contains settings for various moderation features like toxicity detection, AI analysis, and filtering rules.
 
-	
-	### Required Arguments:
-		- `key`
-	### Optional Arguments:
-		- `team`
-	"
+
+  ### Required Arguments:
+  - `key`
+  ### Optional Arguments:
+  - `team`
+  """
   @spec get_config(String.t()) ::
           {:ok, ExStreamClient.Model.GetConfigResponse.t()} | {:error, any()}
   @spec get_config(String.t(), team: String.t()) ::
@@ -765,15 +762,15 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Delete a specific moderation policy by its name
+  @doc ~S"""
+  Delete a specific moderation policy by its name
 
-	
-	### Required Arguments:
-		- `key`
-	### Optional Arguments:
-		- `team`
-	"
+
+  ### Required Arguments:
+  - `key`
+  ### Optional Arguments:
+  - `team`
+  """
   @spec delete_config(String.t()) ::
           {:ok, ExStreamClient.Model.DeleteModerationConfigResponse.t()} | {:error, any()}
   @spec delete_config(String.t(), team: String.t()) ::
@@ -821,13 +818,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Query flags associated with moderation items. This is used for building a moderation dashboard.
+  @doc ~S"""
+  Query flags associated with moderation items. This is used for building a moderation dashboard.
 
-	
-	### Required Arguments:
-		- `payload`: QueryModerationFlagsRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryModerationFlagsRequest`
+  """
   @spec query_moderation_flags(ExStreamClient.Model.QueryModerationFlagsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryModerationFlagsResponse.t()} | {:error, any()}
   def query_moderation_flags(payload) do
@@ -866,13 +863,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Flag any type of content (messages, users, channels, activities) for moderation review. Supports custom content types and additional metadata for flagged content.
+  @doc ~S"""
+  Flag any type of content (messages, users, channels, activities) for moderation review. Supports custom content types and additional metadata for flagged content.
 
-	
-	### Required Arguments:
-		- `payload`: FlagRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.FlagRequest`
+  """
   @spec flag(ExStreamClient.Model.FlagRequest.t()) ::
           {:ok, ExStreamClient.Model.FlagResponse.t()} | {:error, any()}
   def flag(payload) do
@@ -911,13 +908,13 @@ defmodule ExStreamClient.Operations.Moderation do
     end
   end
 
-  @doc ~S"
-	Run moderation checks on the provided content
+  @doc ~S"""
+  Run moderation checks on the provided content
 
-	
-	### Required Arguments:
-		- `payload`: CheckRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CheckRequest`
+  """
   @spec check(ExStreamClient.Model.CheckRequest.t()) ::
           {:ok, ExStreamClient.Model.CheckResponse.t()} | {:error, any()}
   def check(payload) do

--- a/lib/ex_stream_client/operations/og.ex
+++ b/lib/ex_stream_client/operations/og.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Og do
-  @moduledoc "
-	Modules for interacting with the `og` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `og` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Get an OpenGraph attachment for a link
 
-	
-	### Required Arguments:
-		- `url`
-	"
+  @doc ~S"""
+  Get an OpenGraph attachment for a link
+
+
+  ### Required Arguments:
+  - `url`
+  """
   @spec get_og(String.t()) :: {:ok, ExStreamClient.Model.GetOGResponse.t()} | {:error, any()}
   def get_og(url) do
     request_opts = [url: "/api/v2/og", method: :get, params: [url: url]] ++ []

--- a/lib/ex_stream_client/operations/permissions.ex
+++ b/lib/ex_stream_client/operations/permissions.ex
@@ -1,17 +1,16 @@
 defmodule ExStreamClient.Operations.Permissions do
-  @moduledoc "
-	Modules for interacting with the `permissions` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `permissions` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Lists all available permissions
 
-	
-	### Required Arguments:
-		
-	"
+  @doc ~S"""
+  Lists all available permissions
+
+
+  """
   @spec list_permissions() ::
           {:ok, ExStreamClient.Model.ListPermissionsResponse.t()} | {:error, any()}
   def list_permissions() do
@@ -50,13 +49,13 @@ defmodule ExStreamClient.Operations.Permissions do
     end
   end
 
-  @doc ~S"
-	Gets custom permission
+  @doc ~S"""
+  Gets custom permission
 
-	
-	### Required Arguments:
-		- `id`
-	"
+
+  ### Required Arguments:
+  - `id`
+  """
   @spec get_permission(String.t()) ::
           {:ok, ExStreamClient.Model.GetCustomPermissionResponse.t()} | {:error, any()}
   def get_permission(id) do

--- a/lib/ex_stream_client/operations/push_providers.ex
+++ b/lib/ex_stream_client/operations/push_providers.ex
@@ -1,18 +1,19 @@
 defmodule ExStreamClient.Operations.PushProviders do
-  @moduledoc "
-	Modules for interacting with the `push_providers` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `push_providers` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Delete a push provider from v2 with multi bundle/package support. v1 isn't supported in this endpoint
 
-	
-	### Required Arguments:
-		- `type`
-		- `name`
-	"
+  @doc ~S"""
+  Delete a push provider from v2 with multi bundle/package support. v1 isn't supported in this endpoint
+
+
+  ### Required Arguments:
+  - `type`
+  - `name`
+  """
   @spec delete_push_provider(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_push_provider(type, name) do
@@ -52,13 +53,13 @@ defmodule ExStreamClient.Operations.PushProviders do
     end
   end
 
-  @doc ~S"
-	Upsert a push provider for v2 with multi bundle/package support
+  @doc ~S"""
+  Upsert a push provider for v2 with multi bundle/package support
 
-	
-	### Required Arguments:
-		- `payload`: UpsertPushProviderRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UpsertPushProviderRequest`
+  """
   @spec upsert_push_provider(ExStreamClient.Model.UpsertPushProviderRequest.t()) ::
           {:ok, ExStreamClient.Model.UpsertPushProviderResponse.t()} | {:error, any()}
   def upsert_push_provider(payload) do
@@ -97,13 +98,11 @@ defmodule ExStreamClient.Operations.PushProviders do
     end
   end
 
-  @doc ~S"
-	List details of all push providers.
+  @doc ~S"""
+  List details of all push providers.
 
-	
-	### Required Arguments:
-		
-	"
+
+  """
   @spec list_push_providers() ::
           {:ok, ExStreamClient.Model.ListPushProvidersResponse.t()} | {:error, any()}
   def list_push_providers() do

--- a/lib/ex_stream_client/operations/rate_limits.ex
+++ b/lib/ex_stream_client/operations/rate_limits.ex
@@ -1,23 +1,22 @@
 defmodule ExStreamClient.Operations.RateLimits do
-  @moduledoc "
-	Modules for interacting with the `rate_limits` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `rate_limits` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Get rate limits usage and quotas
 
-	
-	### Required Arguments:
-		
-	### Optional Arguments:
-		- `server_side`
-		- `android`
-		- `ios`
-		- `web`
-		- `endpoints`
-	"
+  @doc ~S"""
+  Get rate limits usage and quotas
+
+
+  ### Optional Arguments:
+  - `server_side`
+  - `android`
+  - `ios`
+  - `web`
+  - `endpoints`
+  """
   @spec get_rate_limits() ::
           {:ok, ExStreamClient.Model.GetRateLimitsResponse.t()} | {:error, any()}
   @spec get_rate_limits([

--- a/lib/ex_stream_client/operations/roles.ex
+++ b/lib/ex_stream_client/operations/roles.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Roles do
-  @moduledoc "
-	Modules for interacting with the `roles` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `roles` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Creates custom role
 
-	
-	### Required Arguments:
-		- `payload`: CreateRoleRequest
-	"
+  @doc ~S"""
+  Creates custom role
+
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.CreateRoleRequest`
+  """
   @spec create_role(ExStreamClient.Model.CreateRoleRequest.t()) ::
           {:ok, ExStreamClient.Model.CreateRoleResponse.t()} | {:error, any()}
   def create_role(payload) do
@@ -50,13 +51,11 @@ defmodule ExStreamClient.Operations.Roles do
     end
   end
 
-  @doc ~S"
-	Lists all available roles
+  @doc ~S"""
+  Lists all available roles
 
-	
-	### Required Arguments:
-		
-	"
+
+  """
   @spec list_roles() :: {:ok, ExStreamClient.Model.ListRolesResponse.t()} | {:error, any()}
   def list_roles() do
     request_opts = [url: "/api/v2/roles", method: :get, params: []] ++ []
@@ -94,13 +93,13 @@ defmodule ExStreamClient.Operations.Roles do
     end
   end
 
-  @doc ~S"
-	Deletes custom role
+  @doc ~S"""
+  Deletes custom role
 
-	
-	### Required Arguments:
-		- `name`
-	"
+
+  ### Required Arguments:
+  - `name`
+  """
   @spec delete_role(String.t()) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_role(name) do
     request_opts = [url: "/api/v2/roles/#{name}", method: :delete, params: []] ++ []

--- a/lib/ex_stream_client/operations/tasks.ex
+++ b/lib/ex_stream_client/operations/tasks.ex
@@ -1,17 +1,18 @@
 defmodule ExStreamClient.Operations.Tasks do
-  @moduledoc "
-	Modules for interacting with the `tasks` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `tasks` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Gets status of a task
 
-	
-	### Required Arguments:
-		- `id`
-	"
+  @doc ~S"""
+  Gets status of a task
+
+
+  ### Required Arguments:
+  - `id`
+  """
   @spec get_task(String.t()) :: {:ok, ExStreamClient.Model.GetTaskResponse.t()} | {:error, any()}
   def get_task(id) do
     request_opts = [url: "/api/v2/tasks/#{id}", method: :get, params: []] ++ []

--- a/lib/ex_stream_client/operations/users.ex
+++ b/lib/ex_stream_client/operations/users.ex
@@ -1,21 +1,22 @@
 defmodule ExStreamClient.Operations.Users do
-  @moduledoc "
-	Modules for interacting with the `users` group of Stream APIs
+  @moduledoc ~S"""
+  Modules for interacting with the `users` group of Stream APIs
 
-	API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
-	"
+  API Reference: https://getstream.github.io/protocol/?urls.primaryName=Chat%20v2
+  """
   require Logger
-  @doc ~S"
-	Activates user who's been deactivated previously
 
-Sends events:
-- user.reactivated
+  @doc ~S"""
+  Activates user who's been deactivated previously
 
-	
-	### Required Arguments:
-		- `user_id`
-		- `payload`: ReactivateUserRequest
-	"
+  ### Sends events:
+  - `user.reactivated`
+
+
+  ### Required Arguments:
+  - `user_id`
+  - `payload`: `Elixir.ExStreamClient.Model.ReactivateUserRequest`
+  """
   @spec reactivate_user(String.t(), ExStreamClient.Model.ReactivateUserRequest.t()) ::
           {:ok, ExStreamClient.Model.ReactivateUserResponse.t()} | {:error, any()}
   def reactivate_user(user_id, payload) do
@@ -55,16 +56,16 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Update or create users in bulk
+  @doc ~S"""
+  Update or create users in bulk
 
-Sends events:
-- user.updated
+  ### Sends events:
+  - `user.updated`
 
-	
-	### Required Arguments:
-		- `payload`: UpdateUsersRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateUsersRequest`
+  """
   @spec update_users(ExStreamClient.Model.UpdateUsersRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateUsersResponse.t()} | {:error, any()}
   def update_users(payload) do
@@ -103,18 +104,18 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Updates certain fields of the user
+  @doc ~S"""
+  Updates certain fields of the user
 
-Sends events:
-- user.presence.changed
-- user.updated
-- user.presence.changed
+  ### Sends events:
+  - `user.presence.changed`
+  - `user.updated`
+  - `user.presence.changed`
 
-	
-	### Required Arguments:
-		- `payload`: UpdateUsersPartialRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UpdateUsersPartialRequest`
+  """
   @spec update_users_partial(ExStreamClient.Model.UpdateUsersPartialRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateUsersResponse.t()} | {:error, any()}
   def update_users_partial(payload) do
@@ -153,15 +154,13 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Find and filter users
+  @doc ~S"""
+  Find and filter users
 
-	
-	### Required Arguments:
-		
-	### Optional Arguments:
-		- `payload`: QueryUsersPayload
-	"
+
+  ### Optional Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.QueryUsersPayload`
+  """
   @spec query_users() :: {:ok, ExStreamClient.Model.QueryUsersResponse.t()} | {:error, any()}
   @spec query_users(payload: ExStreamClient.Model.QueryUsersPayload.t()) ::
           {:ok, ExStreamClient.Model.QueryUsersResponse.t()} | {:error, any()}
@@ -208,17 +207,17 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Deletes users and optionally all their belongings asynchronously.
+  @doc ~S"""
+  Deletes users and optionally all their belongings asynchronously.
 
-Sends events:
-- channel.deleted
-- user.deleted
+  ### Sends events:
+  - `channel.deleted`
+  - `user.deleted`
 
-	
-	### Required Arguments:
-		- `payload`: DeleteUsersRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.DeleteUsersRequest`
+  """
   @spec delete_users(ExStreamClient.Model.DeleteUsersRequest.t()) ::
           {:ok, ExStreamClient.Model.DeleteUsersResponse.t()} | {:error, any()}
   def delete_users(payload) do
@@ -257,17 +256,17 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Reactivate users in batches
+  @doc ~S"""
+  Reactivate users in batches
 
-Sends events:
-- user.reactivated
-- user.reactivated
+  ### Sends events:
+  - `user.reactivated`
+  - `user.reactivated`
 
-	
-	### Required Arguments:
-		- `payload`: ReactivateUsersRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.ReactivateUsersRequest`
+  """
   @spec reactivate_users(ExStreamClient.Model.ReactivateUsersRequest.t()) ::
           {:ok, ExStreamClient.Model.ReactivateUsersResponse.t()} | {:error, any()}
   def reactivate_users(payload) do
@@ -306,13 +305,13 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Exports the user's profile, reactions and messages. Raises an error if a user has more than 10k messages or reactions
+  @doc ~S"""
+  Exports the user's profile, reactions and messages. Raises an error if a user has more than 10k messages or reactions
 
-	
-	### Required Arguments:
-		- `user_id`
-	"
+
+  ### Required Arguments:
+  - `user_id`
+  """
   @spec export_user(String.t()) ::
           {:ok, ExStreamClient.Model.ExportUserResponse.t()} | {:error, any()}
   def export_user(user_id) do
@@ -351,16 +350,16 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Deactivate users in batches
+  @doc ~S"""
+  Deactivate users in batches
 
-Sends events:
-- user.deactivated
+  ### Sends events:
+  - `user.deactivated`
 
-	
-	### Required Arguments:
-		- `payload`: DeactivateUsersRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.DeactivateUsersRequest`
+  """
   @spec deactivate_users(ExStreamClient.Model.DeactivateUsersRequest.t()) ::
           {:ok, ExStreamClient.Model.DeactivateUsersResponse.t()} | {:error, any()}
   def deactivate_users(payload) do
@@ -399,13 +398,13 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Restore soft deleted users
+  @doc ~S"""
+  Restore soft deleted users
 
-	
-	### Required Arguments:
-		- `payload`: RestoreUsersRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.RestoreUsersRequest`
+  """
   @spec restore_users(ExStreamClient.Model.RestoreUsersRequest.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def restore_users(payload) do
@@ -444,13 +443,13 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Unblock users
+  @doc ~S"""
+  Unblock users
 
-	
-	### Required Arguments:
-		- `payload`: UnblockUsersRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.UnblockUsersRequest`
+  """
   @spec unblock_users(ExStreamClient.Model.UnblockUsersRequest.t()) ::
           {:ok, ExStreamClient.Model.UnblockUsersResponse.t()} | {:error, any()}
   def unblock_users(payload) do
@@ -489,13 +488,13 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Block users
+  @doc ~S"""
+  Block users
 
-	
-	### Required Arguments:
-		- `payload`: BlockUsersRequest
-	"
+
+  ### Required Arguments:
+  - `payload`: `Elixir.ExStreamClient.Model.BlockUsersRequest`
+  """
   @spec block_users(ExStreamClient.Model.BlockUsersRequest.t()) ::
           {:ok, ExStreamClient.Model.BlockUsersResponse.t()} | {:error, any()}
   def block_users(payload) do
@@ -534,15 +533,13 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Get list of blocked Users
+  @doc ~S"""
+  Get list of blocked Users
 
-	
-	### Required Arguments:
-		
-	### Optional Arguments:
-		- `user_id`
-	"
+
+  ### Optional Arguments:
+  - `user_id`
+  """
   @spec get_blocked_users() ::
           {:ok, ExStreamClient.Model.GetBlockedUsersResponse.t()} | {:error, any()}
   @spec get_blocked_users(user_id: String.t()) ::
@@ -590,17 +587,17 @@ Sends events:
     end
   end
 
-  @doc ~S"
-	Deactivates user with possibility to activate it back
+  @doc ~S"""
+  Deactivates user with possibility to activate it back
 
-Sends events:
-- user.deactivated
+  ### Sends events:
+  - `user.deactivated`
 
-	
-	### Required Arguments:
-		- `user_id`
-		- `payload`: DeactivateUserRequest
-	"
+
+  ### Required Arguments:
+  - `user_id`
+  - `payload`: `Elixir.ExStreamClient.Model.DeactivateUserRequest`
+  """
   @spec deactivate_user(String.t(), ExStreamClient.Model.DeactivateUserRequest.t()) ::
           {:ok, ExStreamClient.Model.DeactivateUserResponse.t()} | {:error, any()}
   def deactivate_user(user_id, payload) do


### PR DESCRIPTION
Previously, the generated output was too deeply nested, resulting in it
being treated as a code block by iex and hexdocs.

To fix this, the `as_heredoc` function has been updated to take a `"""`
delimiter, which ensures that the heredoc syntax is used, instead of
manually generating the whitespace.

In addition to this, required arguments are now only displayed in the
`@doc` block if there are any, otherwise this section is omitted. Where
an argument refers to an elixir module, it is now fully qualified, so
that it generates a link to the module.

The "Sends events" section now uses the same formatting as the
arguments, using a `###` for the heading, and backticks to ensure the
code name is represented correctly. This uses a different technique, as
the events are part of the function description, and not separated out
like the arguments.
