### PR TITLE
fix: error parsing

### DIFF
--- a/lib/ex_stream_client/client.ex
+++ b/lib/ex_stream_client/client.ex
@@ -96,7 +96,7 @@ defmodule ExStreamClient.HTTP do
   end
 
   defp safe_decode_atoms(body) do
-    {:ok, Jason.decode!(body, keys: :atoms!)}
+    {:ok, Jason.decode!(body, keys: :strings)}
   rescue
     _ -> {:error, :invalid_atoms}
   end


### PR DESCRIPTION
Now that we have safer string => atom decoding on the entire payload (as well as case conversion to snake_case), the extra handling for errors is superfluous. 

This removes that handling, which caused errors to not be properly parsed, while still converting string based error responses to json.