### PR TITLE
feat: pass all req_opts to client

### DIFF
--- a/lib/ex_stream_client/operations/app.ex
+++ b/lib/ex_stream_client/operations/app.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.App do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.App do
   def update_app(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/app", method: :patch, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -74,6 +76,7 @@ defmodule ExStreamClient.Operations.App do
   def get_app(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/app", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/blocklists.ex
+++ b/lib/ex_stream_client/operations/blocklists.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Blocklists do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.Blocklists do
   def create_block_list(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/blocklists", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -75,7 +77,8 @@ defmodule ExStreamClient.Operations.Blocklists do
   @spec list_block_lists() ::
           {:ok, ExStreamClient.Model.ListBlockListResponse.t()} | {:error, any()}
   @spec list_block_lists([
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -83,6 +86,7 @@ defmodule ExStreamClient.Operations.Blocklists do
   def list_block_lists(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/blocklists", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -135,6 +139,8 @@ defmodule ExStreamClient.Operations.Blocklists do
     request_opts =
       [url: "/api/v2/blocklists/#{name}", method: :put, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -182,7 +188,8 @@ defmodule ExStreamClient.Operations.Blocklists do
   @spec get_block_list(String.t()) ::
           {:ok, ExStreamClient.Model.GetBlockListResponse.t()} | {:error, any()}
   @spec get_block_list(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -191,6 +198,7 @@ defmodule ExStreamClient.Operations.Blocklists do
   def get_block_list(name, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/blocklists/#{name}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -239,7 +247,8 @@ defmodule ExStreamClient.Operations.Blocklists do
   @spec delete_block_list(String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_block_list(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -248,6 +257,7 @@ defmodule ExStreamClient.Operations.Blocklists do
   def delete_block_list(name, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/blocklists/#{name}", method: :delete, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/campaigns.ex
+++ b/lib/ex_stream_client/operations/chat/campaigns.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -32,6 +33,8 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
 
     request_opts =
       [url: "/api/v2/chat/campaigns/#{id}/stop", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -83,6 +86,8 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
     request_opts =
       [url: "/api/v2/chat/campaigns/query", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -132,7 +137,8 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
   @spec get_campaign(String.t()) ::
           {:ok, ExStreamClient.Model.GetCampaignResponse.t()} | {:error, any()}
   @spec get_campaign(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -141,6 +147,7 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
   def get_campaign(id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/campaigns/#{id}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -192,6 +199,8 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
 
     request_opts =
       [url: "/api/v2/chat/campaigns/#{id}/start", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/channels.ex
+++ b/lib/ex_stream_client/operations/chat/channels.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Channels do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -38,7 +39,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
           String.t(),
           ExStreamClient.Model.UpdateMemberPartialRequest.t(),
           [
-            {:client, module()}
+            {:req_opts, keyword()}
+            | {:client, module()}
             | {:endpoint, String.t()}
             | {:api_key, String.t()}
             | {:api_key_secret, String.t()}
@@ -53,6 +55,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
     request_opts =
       [url: "/api/v2/chat/channels/#{type}/#{id}/member", method: :patch, params: []] ++
         [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -107,6 +111,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       [url: "/api/v2/chat/channels/#{type}/#{id}/unread", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -160,6 +166,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
 
     request_opts =
       [url: "/api/v2/chat/channels/read", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -217,6 +225,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
     request_opts =
       [url: "/api/v2/chat/channels/#{type}/#{id}/hide", method: :post, params: []] ++
         [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -281,6 +291,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       [url: "/api/v2/chat/channels/#{type}/#{id}/query", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -328,6 +340,7 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   def query_channels(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/channels", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -388,6 +401,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       [url: "/api/v2/chat/channels/#{type}/#{id}/message", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -444,6 +459,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
     request_opts =
       [url: "/api/v2/chat/channels/#{type}/#{id}/truncate", method: :post, params: []] ++
         [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -502,6 +519,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       [url: "/api/v2/chat/channels/#{type}/#{id}/show", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -554,6 +573,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
     request_opts =
       [url: "/api/v2/chat/channels/#{type}/#{id}/messages", method: :get, params: [ids: ids]] ++
         []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -608,6 +629,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       [url: "/api/v2/chat/channels/#{type}/#{id}/event", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -657,7 +680,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   @spec get_draft(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.GetDraftResponse.t()} | {:error, any()}
   @spec get_draft(String.t(), String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -669,6 +693,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
 
     request_opts =
       [url: "/api/v2/chat/channels/#{type}/#{id}/draft", method: :get, params: []] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -722,7 +748,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   @spec delete_draft(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_draft(String.t(), String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -734,6 +761,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
 
     request_opts =
       [url: "/api/v2/chat/channels/#{type}/#{id}/draft", method: :delete, params: []] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -788,6 +817,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       [url: "/api/v2/chat/channels/#{type}/#{id}/file", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -836,7 +867,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   @spec delete_file(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_file(String.t(), String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -848,6 +880,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
 
     request_opts =
       [url: "/api/v2/chat/channels/#{type}/#{id}/file", method: :delete, params: []] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -906,6 +940,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       [url: "/api/v2/chat/channels/#{type}/#{id}/read", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -959,6 +995,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       [url: "/api/v2/chat/channels/#{type}/#{id}/image", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -1007,7 +1045,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   @spec delete_image(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_image(String.t(), String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -1019,6 +1058,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
 
     request_opts =
       [url: "/api/v2/chat/channels/#{type}/#{id}/image", method: :delete, params: []] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -1079,6 +1120,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
 
     request_opts =
       [url: "/api/v2/chat/channels/#{type}/query", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -1144,6 +1187,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
     request_opts =
       [url: "/api/v2/chat/channels/#{type}/#{id}", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -1203,6 +1248,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
     request_opts =
       [url: "/api/v2/chat/channels/#{type}/#{id}", method: :patch, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -1255,7 +1302,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   @spec delete_channel(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.DeleteChannelResponse.t()} | {:error, any()}
   @spec delete_channel(String.t(), String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -1265,6 +1313,7 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   def delete_channel(type, id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/channels/#{type}/#{id}", method: :delete, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -1319,6 +1368,8 @@ defmodule ExStreamClient.Operations.Chat.Channels do
 
     request_opts =
       [url: "/api/v2/chat/channels/delete", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/channeltypes.ex
+++ b/lib/ex_stream_client/operations/chat/channeltypes.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -32,6 +33,8 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
 
     request_opts =
       [url: "/api/v2/chat/channeltypes/#{name}", method: :put, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -80,6 +83,7 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
   def get_channel_type(name, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/channeltypes/#{name}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -128,6 +132,7 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
   def delete_channel_type(name, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/channeltypes/#{name}", method: :delete, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -179,6 +184,8 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
     request_opts =
       [url: "/api/v2/chat/channeltypes", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -224,6 +231,7 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
   def list_channel_types(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/channeltypes", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/commands.ex
+++ b/lib/ex_stream_client/operations/chat/commands.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Commands do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.Chat.Commands do
   def create_command(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/commands", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -74,6 +76,7 @@ defmodule ExStreamClient.Operations.Chat.Commands do
   def list_commands(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/commands", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -126,6 +129,8 @@ defmodule ExStreamClient.Operations.Chat.Commands do
     request_opts =
       [url: "/api/v2/chat/commands/#{name}", method: :put, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -173,6 +178,7 @@ defmodule ExStreamClient.Operations.Chat.Commands do
   def get_command(name, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/commands/#{name}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -221,6 +227,7 @@ defmodule ExStreamClient.Operations.Chat.Commands do
   def delete_command(name, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/commands/#{name}", method: :delete, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/drafts.ex
+++ b/lib/ex_stream_client/operations/chat/drafts.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Drafts do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -31,6 +32,8 @@ defmodule ExStreamClient.Operations.Chat.Drafts do
 
     request_opts =
       [url: "/api/v2/chat/drafts/query", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/export_channels.ex
+++ b/lib/ex_stream_client/operations/chat/export_channels.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.ExportChannels do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -31,6 +32,8 @@ defmodule ExStreamClient.Operations.Chat.ExportChannels do
 
     request_opts =
       [url: "/api/v2/chat/export_channels", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/members.ex
+++ b/lib/ex_stream_client/operations/chat/members.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Members do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -26,7 +27,8 @@ defmodule ExStreamClient.Operations.Chat.Members do
   """
   @spec query_members() :: {:ok, ExStreamClient.Model.MembersResponse.t()} | {:error, any()}
   @spec query_members([
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -34,6 +36,7 @@ defmodule ExStreamClient.Operations.Chat.Members do
   def query_members(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/members", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/messages.ex
+++ b/lib/ex_stream_client/operations/chat/messages.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Messages do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -34,7 +35,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   @spec remove_poll_vote(String.t(), String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.PollVoteResponse.t()} | {:error, any()}
   @spec remove_poll_vote(String.t(), String.t(), String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -51,6 +53,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
         method: :delete,
         params: []
       ] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -103,7 +107,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   @spec delete_reaction(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.DeleteReactionResponse.t()} | {:error, any()}
   @spec delete_reaction(String.t(), String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -115,6 +120,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
 
     request_opts =
       [url: "/api/v2/chat/messages/#{id}/reaction/#{type}", method: :delete, params: []] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -171,6 +178,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
     request_opts =
       [url: "/api/v2/chat/messages/#{id}/reaction", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -226,6 +235,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
     request_opts =
       [url: "/api/v2/chat/messages/#{id}/action", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -275,6 +286,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
 
     request_opts =
       [url: "/api/v2/chat/messages/history", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -335,6 +348,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
         params: []
       ] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -386,6 +401,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
     request_opts =
       [url: "/api/v2/chat/messages/#{id}/reactions", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -434,7 +451,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   @spec get_reactions(String.t()) ::
           {:ok, ExStreamClient.Model.GetReactionsResponse.t()} | {:error, any()}
   @spec get_reactions(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -443,6 +461,7 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   def get_reactions(id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/messages/#{id}/reactions", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -503,7 +522,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   @spec get_replies(String.t()) ::
           {:ok, ExStreamClient.Model.GetRepliesResponse.t()} | {:error, any()}
   @spec get_replies(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -514,6 +534,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
 
     request_opts =
       [url: "/api/v2/chat/messages/#{parent_id}/replies", method: :get, params: []] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -570,6 +592,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
     request_opts =
       [url: "/api/v2/chat/messages/#{id}/undelete", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -624,6 +648,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
 
     request_opts =
       [url: "/api/v2/chat/messages/#{id}/translate", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -682,6 +708,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
     request_opts =
       [url: "/api/v2/chat/messages/#{id}/commit", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -736,6 +764,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
 
     request_opts =
       [url: "/api/v2/chat/messages/#{id}", method: :put, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -792,6 +822,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
     request_opts =
       [url: "/api/v2/chat/messages/#{id}", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -839,7 +871,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   @spec get_message(String.t()) ::
           {:ok, ExStreamClient.Model.GetMessageResponse.t()} | {:error, any()}
   @spec get_message(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -848,6 +881,7 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   def get_message(id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/messages/#{id}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -901,7 +935,8 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   @spec delete_message(String.t()) ::
           {:ok, ExStreamClient.Model.DeleteMessageResponse.t()} | {:error, any()}
   @spec delete_message(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -910,6 +945,7 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   def delete_message(id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/messages/#{id}", method: :delete, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/moderation.ex
+++ b/lib/ex_stream_client/operations/chat/moderation.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -27,7 +28,8 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
   @spec query_message_flags() ::
           {:ok, ExStreamClient.Model.QueryMessageFlagsResponse.t()} | {:error, any()}
   @spec query_message_flags([
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -35,6 +37,7 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
   def query_message_flags(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/moderation/flags/message", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -91,6 +94,8 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
       [url: "/api/v2/chat/moderation/unmute/channel", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -144,6 +149,8 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
 
     request_opts =
       [url: "/api/v2/chat/moderation/mute/channel", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/polls.ex
+++ b/lib/ex_stream_client/operations/chat/polls.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Polls do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -30,7 +31,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   @spec query_poll_votes(String.t(), ExStreamClient.Model.QueryPollVotesRequest.t()) ::
           {:ok, ExStreamClient.Model.PollVotesResponse.t()} | {:error, any()}
   @spec query_poll_votes(String.t(), ExStreamClient.Model.QueryPollVotesRequest.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -42,6 +44,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
 
     request_opts =
       [url: "/api/v2/chat/polls/#{poll_id}/votes", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -94,6 +98,7 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   def update_poll(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/polls", method: :put, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -142,6 +147,7 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   def create_poll(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/polls", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -197,6 +203,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
     request_opts =
       [url: "/api/v2/chat/polls/#{poll_id}/options", method: :put, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -250,6 +258,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
 
     request_opts =
       [url: "/api/v2/chat/polls/#{poll_id}/options", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -305,6 +315,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
     request_opts =
       [url: "/api/v2/chat/polls/#{poll_id}", method: :patch, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -351,7 +363,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   """
   @spec get_poll(String.t()) :: {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
   @spec get_poll(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -360,6 +373,7 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   def get_poll(poll_id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/polls/#{poll_id}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -410,7 +424,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   """
   @spec delete_poll(String.t()) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_poll(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -419,6 +434,7 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   def delete_poll(poll_id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/polls/#{poll_id}", method: :delete, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -467,7 +483,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   @spec query_polls(ExStreamClient.Model.QueryPollsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryPollsResponse.t()} | {:error, any()}
   @spec query_polls(ExStreamClient.Model.QueryPollsRequest.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -476,6 +493,7 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   def query_polls(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/polls/query", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -525,7 +543,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   @spec get_poll_option(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.PollOptionResponse.t()} | {:error, any()}
   @spec get_poll_option(String.t(), String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -537,6 +556,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
 
     request_opts =
       [url: "/api/v2/chat/polls/#{poll_id}/options/#{option_id}", method: :get, params: []] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -589,7 +610,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   @spec delete_poll_option(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_poll_option(String.t(), String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -602,6 +624,8 @@ defmodule ExStreamClient.Operations.Chat.Polls do
     request_opts =
       [url: "/api/v2/chat/polls/#{poll_id}/options/#{option_id}", method: :delete, params: []] ++
         []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/push_preferences.ex
+++ b/lib/ex_stream_client/operations/chat/push_preferences.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.PushPreferences do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -32,6 +33,8 @@ defmodule ExStreamClient.Operations.Chat.PushPreferences do
 
     request_opts =
       [url: "/api/v2/chat/push_preferences", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/push_templates.ex
+++ b/lib/ex_stream_client/operations/chat/push_templates.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.PushTemplates do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -31,6 +32,8 @@ defmodule ExStreamClient.Operations.Chat.PushTemplates do
 
     request_opts =
       [url: "/api/v2/chat/push_templates", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -79,7 +82,8 @@ defmodule ExStreamClient.Operations.Chat.PushTemplates do
   @spec get_push_templates(String.t()) ::
           {:ok, ExStreamClient.Model.GetPushTemplatesResponse.t()} | {:error, any()}
   @spec get_push_templates(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -96,6 +100,8 @@ defmodule ExStreamClient.Operations.Chat.PushTemplates do
           Keyword.merge([push_provider_type: push_provider_type], Keyword.take(opts, []))
           |> Enum.reject(fn {_k, v} -> is_nil(v) end)
       ] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/query_banned_users.ex
+++ b/lib/ex_stream_client/operations/chat/query_banned_users.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.QueryBannedUsers do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -27,7 +28,8 @@ defmodule ExStreamClient.Operations.Chat.QueryBannedUsers do
   @spec query_banned_users() ::
           {:ok, ExStreamClient.Model.QueryBannedUsersResponse.t()} | {:error, any()}
   @spec query_banned_users([
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -35,6 +37,7 @@ defmodule ExStreamClient.Operations.Chat.QueryBannedUsers do
   def query_banned_users(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/query_banned_users", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/search.ex
+++ b/lib/ex_stream_client/operations/chat/search.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Search do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -26,7 +27,8 @@ defmodule ExStreamClient.Operations.Chat.Search do
   """
   @spec search() :: {:ok, ExStreamClient.Model.SearchResponse.t()} | {:error, any()}
   @spec search([
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -34,6 +36,7 @@ defmodule ExStreamClient.Operations.Chat.Search do
   def search(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/search", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/segments.ex
+++ b/lib/ex_stream_client/operations/chat/segments.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Segments do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.Chat.Segments do
   def get_segment(id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/segments/#{id}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -76,6 +78,7 @@ defmodule ExStreamClient.Operations.Chat.Segments do
   def delete_segment(id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/segments/#{id}", method: :delete, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -129,6 +132,8 @@ defmodule ExStreamClient.Operations.Chat.Segments do
       [url: "/api/v2/chat/segments/#{id}/targets/query", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -178,6 +183,8 @@ defmodule ExStreamClient.Operations.Chat.Segments do
 
     request_opts =
       [url: "/api/v2/chat/segments/query", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -231,6 +238,8 @@ defmodule ExStreamClient.Operations.Chat.Segments do
       [url: "/api/v2/chat/segments/#{id}/deletetargets", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -281,6 +290,8 @@ defmodule ExStreamClient.Operations.Chat.Segments do
 
     request_opts =
       [url: "/api/v2/chat/segments/#{id}/target/#{target_id}", method: :get, params: []] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/threads.ex
+++ b/lib/ex_stream_client/operations/chat/threads.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Threads do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -36,6 +37,8 @@ defmodule ExStreamClient.Operations.Chat.Threads do
 
     request_opts =
       [url: "/api/v2/chat/threads/#{message_id}", method: :patch, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -86,7 +89,8 @@ defmodule ExStreamClient.Operations.Chat.Threads do
   @spec get_thread(String.t()) ::
           {:ok, ExStreamClient.Model.GetThreadResponse.t()} | {:error, any()}
   @spec get_thread(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -95,6 +99,7 @@ defmodule ExStreamClient.Operations.Chat.Threads do
   def get_thread(message_id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/threads/#{message_id}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -143,6 +148,7 @@ defmodule ExStreamClient.Operations.Chat.Threads do
   def query_threads(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/threads", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/unread.ex
+++ b/lib/ex_stream_client/operations/chat/unread.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Unread do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -27,6 +28,7 @@ defmodule ExStreamClient.Operations.Chat.Unread do
   def unread_counts(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/unread", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/unread_batch.ex
+++ b/lib/ex_stream_client/operations/chat/unread_batch.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.UnreadBatch do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -31,6 +32,8 @@ defmodule ExStreamClient.Operations.Chat.UnreadBatch do
 
     request_opts =
       [url: "/api/v2/chat/unread_batch", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/chat/users.ex
+++ b/lib/ex_stream_client/operations/chat/users.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Chat.Users do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -35,6 +36,8 @@ defmodule ExStreamClient.Operations.Chat.Users do
 
     request_opts =
       [url: "/api/v2/chat/users/#{user_id}/event", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/check_push.ex
+++ b/lib/ex_stream_client/operations/check_push.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.CheckPush do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.CheckPush do
   def check_push(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/check_push", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/check_sns.ex
+++ b/lib/ex_stream_client/operations/check_sns.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.CheckSns do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.CheckSns do
   def check_sns(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/check_sns", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/check_sqs.ex
+++ b/lib/ex_stream_client/operations/check_sqs.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.CheckSqs do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.CheckSqs do
   def check_sqs(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/check_sqs", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/devices.ex
+++ b/lib/ex_stream_client/operations/devices.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Devices do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.Devices do
   def create_device(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/devices", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -74,7 +76,8 @@ defmodule ExStreamClient.Operations.Devices do
   """
   @spec list_devices() :: {:ok, ExStreamClient.Model.ListDevicesResponse.t()} | {:error, any()}
   @spec list_devices([
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -82,6 +85,7 @@ defmodule ExStreamClient.Operations.Devices do
   def list_devices(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/devices", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -129,7 +133,8 @@ defmodule ExStreamClient.Operations.Devices do
   """
   @spec delete_device(String.t()) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_device(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -146,6 +151,8 @@ defmodule ExStreamClient.Operations.Devices do
           Keyword.merge([id: id], Keyword.take(opts, []))
           |> Enum.reject(fn {_k, v} -> is_nil(v) end)
       ] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/export.ex
+++ b/lib/ex_stream_client/operations/export.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Export do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.Export do
   def export_users(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/export/users", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/external_storage.ex
+++ b/lib/ex_stream_client/operations/external_storage.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.ExternalStorage do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.ExternalStorage do
   def check_external_storage(name, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/external_storage/#{name}/check", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -77,6 +79,7 @@ defmodule ExStreamClient.Operations.ExternalStorage do
   def create_external_storage(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/external_storage", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -123,6 +126,7 @@ defmodule ExStreamClient.Operations.ExternalStorage do
   def list_external_storage(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/external_storage", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -175,6 +179,8 @@ defmodule ExStreamClient.Operations.ExternalStorage do
     request_opts =
       [url: "/api/v2/external_storage/#{name}", method: :put, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -222,6 +228,7 @@ defmodule ExStreamClient.Operations.ExternalStorage do
   def delete_external_storage(name, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/external_storage/#{name}", method: :delete, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/guest.ex
+++ b/lib/ex_stream_client/operations/guest.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Guest do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.Guest do
   def create_guest(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/guest", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/import_urls.ex
+++ b/lib/ex_stream_client/operations/import_urls.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.ImportUrls do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.ImportUrls do
   def create_import_url(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/import_urls", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/imports.ex
+++ b/lib/ex_stream_client/operations/imports.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Imports do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.Imports do
   def get_import(id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/imports/#{id}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -77,6 +79,7 @@ defmodule ExStreamClient.Operations.Imports do
   def create_import(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/imports", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -122,6 +125,7 @@ defmodule ExStreamClient.Operations.Imports do
   def list_imports(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/imports", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/moderation.ex
+++ b/lib/ex_stream_client/operations/moderation.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Moderation do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -31,6 +32,8 @@ defmodule ExStreamClient.Operations.Moderation do
 
     request_opts =
       [url: "/api/v2/moderation/custom_check", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -81,7 +84,8 @@ defmodule ExStreamClient.Operations.Moderation do
   @spec unban(String.t(), ExStreamClient.Model.UnbanRequest.t()) ::
           {:ok, ExStreamClient.Model.UnbanResponse.t()} | {:error, any()}
   @spec unban(String.t(), ExStreamClient.Model.UnbanRequest.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -99,6 +103,8 @@ defmodule ExStreamClient.Operations.Moderation do
           Keyword.merge([target_user_id: target_user_id], Keyword.take(opts, []))
           |> Enum.reject(fn {_k, v} -> is_nil(v) end)
       ] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -150,6 +156,8 @@ defmodule ExStreamClient.Operations.Moderation do
     request_opts =
       [url: "/api/v2/moderation/submit_action", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -199,6 +207,8 @@ defmodule ExStreamClient.Operations.Moderation do
 
     request_opts =
       [url: "/api/v2/moderation/unmute", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -250,6 +260,8 @@ defmodule ExStreamClient.Operations.Moderation do
     request_opts =
       [url: "/api/v2/moderation/configs", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -297,6 +309,7 @@ defmodule ExStreamClient.Operations.Moderation do
   def get_review_queue_item(id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/moderation/review_queue/#{id}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -349,6 +362,8 @@ defmodule ExStreamClient.Operations.Moderation do
       [url: "/api/v2/moderation/bulk_image_moderation", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -396,6 +411,7 @@ defmodule ExStreamClient.Operations.Moderation do
   def query_moderation_logs(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/moderation/logs", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -448,6 +464,8 @@ defmodule ExStreamClient.Operations.Moderation do
       [url: "/api/v2/moderation/feeds_moderation_template", method: :post, params: []] ++
         [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -495,6 +513,8 @@ defmodule ExStreamClient.Operations.Moderation do
 
     request_opts =
       [url: "/api/v2/moderation/feeds_moderation_template", method: :get, params: []] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -544,6 +564,8 @@ defmodule ExStreamClient.Operations.Moderation do
     request_opts =
       [url: "/api/v2/moderation/feeds_moderation_template", method: :delete, params: []] ++ []
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -591,6 +613,7 @@ defmodule ExStreamClient.Operations.Moderation do
   def mute(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/moderation/mute", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -639,6 +662,7 @@ defmodule ExStreamClient.Operations.Moderation do
   def ban(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/moderation/ban", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -690,6 +714,8 @@ defmodule ExStreamClient.Operations.Moderation do
     request_opts =
       [url: "/api/v2/moderation/config", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -740,6 +766,8 @@ defmodule ExStreamClient.Operations.Moderation do
     request_opts =
       [url: "/api/v2/moderation/review_queue", method: :post, params: []] ++ [json: payload]
 
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
     r =
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
@@ -787,7 +815,8 @@ defmodule ExStreamClient.Operations.Moderation do
   @spec get_config(String.t()) ::
           {:ok, ExStreamClient.Model.GetConfigResponse.t()} | {:error, any()}
   @spec get_config(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -796,6 +825,7 @@ defmodule ExStreamClient.Operations.Moderation do
   def get_config(key, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/moderation/config/#{key}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -844,7 +874,8 @@ defmodule ExStreamClient.Operations.Moderation do
   @spec delete_config(String.t()) ::
           {:ok, ExStreamClient.Model.DeleteModerationConfigResponse.t()} | {:error, any()}
   @spec delete_config(String.t(), [
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -853,6 +884,7 @@ defmodule ExStreamClient.Operations.Moderation do
   def delete_config(key, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/moderation/config/#{key}", method: :delete, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -901,6 +933,7 @@ defmodule ExStreamClient.Operations.Moderation do
   def query_moderation_flags(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/moderation/flags", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -949,6 +982,7 @@ defmodule ExStreamClient.Operations.Moderation do
   def flag(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/moderation/flag", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -997,6 +1031,7 @@ defmodule ExStreamClient.Operations.Moderation do
   def check(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/moderation/check", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/og.ex
+++ b/lib/ex_stream_client/operations/og.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Og do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -28,6 +29,7 @@ defmodule ExStreamClient.Operations.Og do
   def get_og(url, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/og", method: :get, params: [url: url]] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/permissions.ex
+++ b/lib/ex_stream_client/operations/permissions.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Permissions do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -27,6 +28,7 @@ defmodule ExStreamClient.Operations.Permissions do
   def list_permissions(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/permissions", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -75,6 +77,7 @@ defmodule ExStreamClient.Operations.Permissions do
   def get_permission(id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/permissions/#{id}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/push_providers.ex
+++ b/lib/ex_stream_client/operations/push_providers.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.PushProviders do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -32,6 +33,8 @@ defmodule ExStreamClient.Operations.PushProviders do
 
     request_opts =
       [url: "/api/v2/push_providers/#{type}/#{name}", method: :delete, params: []] ++ []
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -80,6 +83,7 @@ defmodule ExStreamClient.Operations.PushProviders do
   def upsert_push_provider(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/push_providers", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -126,6 +130,7 @@ defmodule ExStreamClient.Operations.PushProviders do
   def list_push_providers(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/push_providers", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/rate_limits.ex
+++ b/lib/ex_stream_client/operations/rate_limits.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.RateLimits do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -31,7 +32,8 @@ defmodule ExStreamClient.Operations.RateLimits do
   @spec get_rate_limits() ::
           {:ok, ExStreamClient.Model.GetRateLimitsResponse.t()} | {:error, any()}
   @spec get_rate_limits([
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -39,6 +41,7 @@ defmodule ExStreamClient.Operations.RateLimits do
   def get_rate_limits(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/rate_limits", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/roles.ex
+++ b/lib/ex_stream_client/operations/roles.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Roles do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -29,6 +30,7 @@ defmodule ExStreamClient.Operations.Roles do
   def create_role(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/roles", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -74,6 +76,7 @@ defmodule ExStreamClient.Operations.Roles do
   def list_roles(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/roles", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -121,6 +124,7 @@ defmodule ExStreamClient.Operations.Roles do
   def delete_role(name, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/roles/#{name}", method: :delete, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/tasks.ex
+++ b/lib/ex_stream_client/operations/tasks.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Tasks do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -28,6 +29,7 @@ defmodule ExStreamClient.Operations.Tasks do
   def get_task(id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/tasks/#{id}", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/lib/ex_stream_client/operations/users.ex
+++ b/lib/ex_stream_client/operations/users.ex
@@ -12,6 +12,7 @@ defmodule ExStreamClient.Operations.Users do
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
+   * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options
   """
   require Logger
 
@@ -35,6 +36,8 @@ defmodule ExStreamClient.Operations.Users do
 
     request_opts =
       [url: "/api/v2/users/#{user_id}/reactivate", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -86,6 +89,7 @@ defmodule ExStreamClient.Operations.Users do
   def update_users(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/users", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -139,6 +143,7 @@ defmodule ExStreamClient.Operations.Users do
   def update_users_partial(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/users", method: :patch, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -184,7 +189,8 @@ defmodule ExStreamClient.Operations.Users do
   """
   @spec query_users() :: {:ok, ExStreamClient.Model.QueryUsersResponse.t()} | {:error, any()}
   @spec query_users([
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -192,6 +198,7 @@ defmodule ExStreamClient.Operations.Users do
   def query_users(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/users", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -244,6 +251,7 @@ defmodule ExStreamClient.Operations.Users do
   def delete_users(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/users/delete", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -296,6 +304,7 @@ defmodule ExStreamClient.Operations.Users do
   def reactivate_users(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/users/reactivate", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -344,6 +353,7 @@ defmodule ExStreamClient.Operations.Users do
   def export_user(user_id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/users/#{user_id}/export", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -395,6 +405,7 @@ defmodule ExStreamClient.Operations.Users do
   def deactivate_users(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/users/deactivate", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -443,6 +454,7 @@ defmodule ExStreamClient.Operations.Users do
   def restore_users(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/users/restore", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -491,6 +503,7 @@ defmodule ExStreamClient.Operations.Users do
   def unblock_users(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/users/unblock", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -539,6 +552,7 @@ defmodule ExStreamClient.Operations.Users do
   def block_users(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/users/block", method: :post, params: []] ++ [json: payload]
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -585,7 +599,8 @@ defmodule ExStreamClient.Operations.Users do
   @spec get_blocked_users() ::
           {:ok, ExStreamClient.Model.GetBlockedUsersResponse.t()} | {:error, any()}
   @spec get_blocked_users([
-          {:client, module()}
+          {:req_opts, keyword()}
+          | {:client, module()}
           | {:endpoint, String.t()}
           | {:api_key, String.t()}
           | {:api_key_secret, String.t()}
@@ -593,6 +608,7 @@ defmodule ExStreamClient.Operations.Users do
   def get_blocked_users(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/users/block", method: :get, params: []] ++ []
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)
@@ -647,6 +663,8 @@ defmodule ExStreamClient.Operations.Users do
 
     request_opts =
       [url: "/api/v2/users/#{user_id}/deactivate", method: :post, params: []] ++ [json: payload]
+
+    request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
 
     r =
       Req.new(request_opts)

--- a/tools/codegen.ex
+++ b/tools/codegen.ex
@@ -851,6 +851,7 @@ defmodule ExStreamClient.Tools.Codegen do
   def type_to_spec("integer"), do: quote(do: integer())
   def type_to_spec("boolean"), do: quote(do: boolean())
   def type_to_spec("string"), do: quote(do: String.t())
+  def type_to_spec("keyword"), do: quote(do: keyword())
   def type_to_spec("bitstring"), do: quote(do: bitstring() | {String.t(), bitstring()})
   # TODO: handle these types here better
   def type_to_spec("array"), do: quote(do: list())

--- a/tools/codegen/generate_operations.ex
+++ b/tools/codegen/generate_operations.ex
@@ -101,6 +101,14 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
                 description: "HTTP client to use. Must implement `ExStreamClient.Http.Behavior`",
                 required?: false,
                 example: "ExStreamClient.Http"
+              },
+              %{
+                in: "opts",
+                name: "req_opts",
+                type: "keyword",
+                description: "all of these options will be forwarded to req. See `Req.new/1` for available options",
+                required?: false,
+                example: "[plug: MyTest.Plug]"
               }
             ])
 
@@ -288,6 +296,8 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
                     params: unquote(query_params_ast)
                   ] ++ unquote(body_params)
 
+                request_opts = Keyword.merge(request_opts, Keyword.get(opts, :req_opts, []))
+
                 r =
                   Req.new(request_opts)
                   |> Req.Request.append_response_steps(
@@ -334,6 +344,7 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
           " * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used",
           " * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used",
           " * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`",
+          " * `req_opts` - all of these options will be forwarded to req. See `Req.new/1` for available options",
           ""
         ]
         |> Enum.join("\n")


### PR DESCRIPTION
Now all of the req_opts are passed to the client. This simplifies
testing by supporting the req `plug` option.

https://hexdocs.pm/req/Req.Test.html

```
plug = fn conn ->
  conn
  |> Plug.Conn.put_resp_content_type("application/json")
  |> Plug.Conn.send_resp(200, ~s|{"app": {"name":"MyApp"}}|)
end

ExStreamClient.Operations.App.get_app(
  [api_key: "", api_key_secret: "", req_opts: [plug: plug]])
```