### PR TITLE
fix: typespecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,8 @@ ex_stream_client-*.tar
 # Temporary files, for example, from tests.
 /tmp/
 
+# ignore macos files
+.DS_Store
+
+# Ignore local config
 /config/dev.secret.exs

--- a/lib/ex_stream_client/operations/app.ex
+++ b/lib/ex_stream_client/operations/app.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.App do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   This Method updates one or more application settings
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.UpdateAppRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_app(ExStreamClient.Model.UpdateAppRequest.t()) ::
+          {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec update_app(ExStreamClient.Model.UpdateAppRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def update_app(payload, opts \\ []) do
     client = get_client(opts)
@@ -36,26 +45,13 @@ defmodule ExStreamClient.Operations.App do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -69,10 +65,12 @@ defmodule ExStreamClient.Operations.App do
   This Method returns the application settings
 
 
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_app() :: {:ok, ExStreamClient.Model.GetApplicationResponse.t()} | {:error, any()}
+  @spec get_app(shared_opts) ::
+          {:ok, ExStreamClient.Model.GetApplicationResponse.t()} | {:error, any()}
   def get_app(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/app", method: :get, params: []] ++ []
@@ -82,26 +80,13 @@ defmodule ExStreamClient.Operations.App do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetApplicationResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -120,6 +105,21 @@ defmodule ExStreamClient.Operations.App do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/blocklists.ex
+++ b/lib/ex_stream_client/operations/blocklists.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.Blocklists do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Creates a new application blocklist, once created the blocklist can be used by any channel type
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CreateBlockListRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec create_block_list(ExStreamClient.Model.CreateBlockListRequest.t()) ::
+          {:ok, ExStreamClient.Model.CreateBlockListResponse.t()} | {:error, any()}
+  @spec create_block_list(ExStreamClient.Model.CreateBlockListRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CreateBlockListResponse.t()} | {:error, any()}
   def create_block_list(payload, opts \\ []) do
     client = get_client(opts)
@@ -36,26 +45,13 @@ defmodule ExStreamClient.Operations.Blocklists do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CreateBlockListResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -71,19 +67,12 @@ defmodule ExStreamClient.Operations.Blocklists do
 
   ### Optional Arguments:
   - `team`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec list_block_lists() ::
           {:ok, ExStreamClient.Model.ListBlockListResponse.t()} | {:error, any()}
-  @spec list_block_lists([
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:team, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.ListBlockListResponse.t()} | {:error, any()}
+  @spec list_block_lists([{:team, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.ListBlockListResponse.t()} | {:error, any()}
   def list_block_lists(opts \\ []) do
     client = get_client(opts)
 
@@ -102,26 +91,13 @@ defmodule ExStreamClient.Operations.Blocklists do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.ListBlockListResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -138,11 +114,16 @@ defmodule ExStreamClient.Operations.Blocklists do
   ### Required Arguments:
   - `name`
   - `payload`: `Elixir.ExStreamClient.Model.UpdateBlockListRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_block_list(String.t(), ExStreamClient.Model.UpdateBlockListRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateBlockListResponse.t()} | {:error, any()}
+  @spec update_block_list(
+          String.t(),
+          ExStreamClient.Model.UpdateBlockListRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.UpdateBlockListResponse.t()} | {:error, any()}
   def update_block_list(name, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -155,26 +136,13 @@ defmodule ExStreamClient.Operations.Blocklists do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UpdateBlockListResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -192,19 +160,12 @@ defmodule ExStreamClient.Operations.Blocklists do
   - `name`
   ### Optional Arguments:
   - `team`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_block_list(String.t()) ::
           {:ok, ExStreamClient.Model.GetBlockListResponse.t()} | {:error, any()}
-  @spec get_block_list(String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:team, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.GetBlockListResponse.t()} | {:error, any()}
+  @spec get_block_list(String.t(), [{:team, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.GetBlockListResponse.t()} | {:error, any()}
   def get_block_list(name, opts \\ []) do
     client = get_client(opts)
 
@@ -223,26 +184,13 @@ defmodule ExStreamClient.Operations.Blocklists do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetBlockListResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -260,19 +208,12 @@ defmodule ExStreamClient.Operations.Blocklists do
   - `name`
   ### Optional Arguments:
   - `team`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_block_list(String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
-  @spec delete_block_list(String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:team, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec delete_block_list(String.t(), [{:team, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_block_list(name, opts \\ []) do
     client = get_client(opts)
 
@@ -291,26 +232,13 @@ defmodule ExStreamClient.Operations.Blocklists do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -329,6 +257,21 @@ defmodule ExStreamClient.Operations.Blocklists do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/chat/campaigns.ex
+++ b/lib/ex_stream_client/operations/chat/campaigns.ex
@@ -16,6 +16,13 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Stops a campaign
 
@@ -23,10 +30,12 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.StopCampaignRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec schedule_campaign(String.t(), ExStreamClient.Model.StopCampaignRequest.t()) ::
+          {:ok, ExStreamClient.Model.CampaignResponse.t()} | {:error, any()}
+  @spec schedule_campaign(String.t(), ExStreamClient.Model.StopCampaignRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CampaignResponse.t()} | {:error, any()}
   def schedule_campaign(id, payload, opts \\ []) do
     client = get_client(opts)
@@ -40,26 +49,13 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CampaignResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -75,10 +71,12 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.QueryCampaignsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_campaigns(ExStreamClient.Model.QueryCampaignsRequest.t()) ::
+          {:ok, ExStreamClient.Model.QueryCampaignsResponse.t()} | {:error, any()}
+  @spec query_campaigns(ExStreamClient.Model.QueryCampaignsRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.QueryCampaignsResponse.t()} | {:error, any()}
   def query_campaigns(payload, opts \\ []) do
     client = get_client(opts)
@@ -92,26 +90,13 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QueryCampaignsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -131,20 +116,12 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
   - `limit`
   - `next`
   - `prev`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_campaign(String.t()) ::
           {:ok, ExStreamClient.Model.GetCampaignResponse.t()} | {:error, any()}
   @spec get_campaign(String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:limit, integer()}
-          | {:next, String.t()}
-          | {:prev, String.t()}
+          ({:limit, integer()} | {:next, String.t()} | {:prev, String.t()}) | shared_opts
         ]) :: {:ok, ExStreamClient.Model.GetCampaignResponse.t()} | {:error, any()}
   def get_campaign(id, opts \\ []) do
     client = get_client(opts)
@@ -164,26 +141,13 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetCampaignResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -200,10 +164,12 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.StartCampaignRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec start_campaign(String.t(), ExStreamClient.Model.StartCampaignRequest.t()) ::
+          {:ok, ExStreamClient.Model.StartCampaignResponse.t()} | {:error, any()}
+  @spec start_campaign(String.t(), ExStreamClient.Model.StartCampaignRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.StartCampaignResponse.t()} | {:error, any()}
   def start_campaign(id, payload, opts \\ []) do
     client = get_client(opts)
@@ -217,26 +183,13 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.StartCampaignResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -255,6 +208,21 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/chat/channels.ex
+++ b/lib/ex_stream_client/operations/chat/channels.ex
@@ -16,6 +16,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
 
 
@@ -26,8 +33,7 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `payload`: `Elixir.ExStreamClient.Model.UpdateMemberPartialRequest`
   ### Optional Arguments:
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_member_partial(
           String.t(),
@@ -38,14 +44,7 @@ defmodule ExStreamClient.Operations.Chat.Channels do
           String.t(),
           String.t(),
           ExStreamClient.Model.UpdateMemberPartialRequest.t(),
-          [
-            {:req_opts, keyword()}
-            | {:client, module()}
-            | {:endpoint, String.t()}
-            | {:api_key, String.t()}
-            | {:api_key_secret, String.t()}
-            | {:user_id, String.t()}
-          ]
+          [{:user_id, String.t()} | shared_opts]
         ) :: {:ok, ExStreamClient.Model.UpdateMemberPartialResponse.t()} | {:error, any()}
   def update_member_partial(type, id, payload, opts \\ []) do
     client = get_client(opts)
@@ -65,26 +64,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.UpdateMemberPartialResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -102,11 +88,17 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.MarkUnreadRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec mark_unread(String.t(), String.t(), ExStreamClient.Model.MarkUnreadRequest.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec mark_unread(
+          String.t(),
+          String.t(),
+          ExStreamClient.Model.MarkUnreadRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def mark_unread(type, id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -120,26 +112,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -159,10 +138,12 @@ defmodule ExStreamClient.Operations.Chat.Channels do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.MarkChannelsReadRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec mark_channels_read(ExStreamClient.Model.MarkChannelsReadRequest.t()) ::
+          {:ok, ExStreamClient.Model.MarkReadResponse.t()} | {:error, any()}
+  @spec mark_channels_read(ExStreamClient.Model.MarkChannelsReadRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.MarkReadResponse.t()} | {:error, any()}
   def mark_channels_read(payload, opts \\ []) do
     client = get_client(opts)
@@ -176,26 +157,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.MarkReadResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -217,11 +185,17 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.HideChannelRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec hide_channel(String.t(), String.t(), ExStreamClient.Model.HideChannelRequest.t()) ::
           {:ok, ExStreamClient.Model.HideChannelResponse.t()} | {:error, any()}
+  @spec hide_channel(
+          String.t(),
+          String.t(),
+          ExStreamClient.Model.HideChannelRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.HideChannelResponse.t()} | {:error, any()}
   def hide_channel(type, id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -235,26 +209,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.HideChannelResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -279,13 +240,19 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.ChannelGetOrCreateRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_or_create_channel(
           String.t(),
           String.t(),
           ExStreamClient.Model.ChannelGetOrCreateRequest.t()
+        ) :: {:ok, ExStreamClient.Model.ChannelStateResponse.t()} | {:error, any()}
+  @spec get_or_create_channel(
+          String.t(),
+          String.t(),
+          ExStreamClient.Model.ChannelGetOrCreateRequest.t(),
+          shared_opts
         ) :: {:ok, ExStreamClient.Model.ChannelStateResponse.t()} | {:error, any()}
   def get_or_create_channel(type, id, payload, opts \\ []) do
     client = get_client(opts)
@@ -300,26 +267,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.ChannelStateResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -335,10 +289,12 @@ defmodule ExStreamClient.Operations.Chat.Channels do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.QueryChannelsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_channels(ExStreamClient.Model.QueryChannelsRequest.t()) ::
+          {:ok, ExStreamClient.Model.QueryChannelsResponse.t()} | {:error, any()}
+  @spec query_channels(ExStreamClient.Model.QueryChannelsRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.QueryChannelsResponse.t()} | {:error, any()}
   def query_channels(payload, opts \\ []) do
     client = get_client(opts)
@@ -349,26 +305,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QueryChannelsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -392,11 +335,17 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.SendMessageRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec send_message(String.t(), String.t(), ExStreamClient.Model.SendMessageRequest.t()) ::
           {:ok, ExStreamClient.Model.SendMessageResponse.t()} | {:error, any()}
+  @spec send_message(
+          String.t(),
+          String.t(),
+          ExStreamClient.Model.SendMessageRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.SendMessageResponse.t()} | {:error, any()}
   def send_message(type, id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -410,26 +359,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.SendMessageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -451,11 +387,17 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.TruncateChannelRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec truncate_channel(String.t(), String.t(), ExStreamClient.Model.TruncateChannelRequest.t()) ::
           {:ok, ExStreamClient.Model.TruncateChannelResponse.t()} | {:error, any()}
+  @spec truncate_channel(
+          String.t(),
+          String.t(),
+          ExStreamClient.Model.TruncateChannelRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.TruncateChannelResponse.t()} | {:error, any()}
   def truncate_channel(type, id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -469,26 +411,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.TruncateChannelResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -510,11 +439,17 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.ShowChannelRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec show_channel(String.t(), String.t(), ExStreamClient.Model.ShowChannelRequest.t()) ::
           {:ok, ExStreamClient.Model.ShowChannelResponse.t()} | {:error, any()}
+  @spec show_channel(
+          String.t(),
+          String.t(),
+          ExStreamClient.Model.ShowChannelRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.ShowChannelResponse.t()} | {:error, any()}
   def show_channel(type, id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -528,26 +463,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.ShowChannelResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -565,10 +487,12 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `ids`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_many_messages(String.t(), String.t(), list()) ::
+          {:ok, ExStreamClient.Model.GetManyMessagesResponse.t()} | {:error, any()}
+  @spec get_many_messages(String.t(), String.t(), list(), shared_opts) ::
           {:ok, ExStreamClient.Model.GetManyMessagesResponse.t()} | {:error, any()}
   def get_many_messages(type, id, ids, opts \\ []) do
     client = get_client(opts)
@@ -583,26 +507,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetManyMessagesResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -620,10 +531,12 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.SendEventRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec send_event(String.t(), String.t(), ExStreamClient.Model.SendEventRequest.t()) ::
+          {:ok, ExStreamClient.Model.EventResponse.t()} | {:error, any()}
+  @spec send_event(String.t(), String.t(), ExStreamClient.Model.SendEventRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.EventResponse.t()} | {:error, any()}
   def send_event(type, id, payload, opts \\ []) do
     client = get_client(opts)
@@ -638,26 +551,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.EventResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -677,19 +577,12 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   ### Optional Arguments:
   - `parent_id`
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_draft(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.GetDraftResponse.t()} | {:error, any()}
   @spec get_draft(String.t(), String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:user_id, String.t()}
-          | {:parent_id, String.t()}
+          ({:user_id, String.t()} | {:parent_id, String.t()}) | shared_opts
         ]) :: {:ok, ExStreamClient.Model.GetDraftResponse.t()} | {:error, any()}
   def get_draft(type, id, opts \\ []) do
     client = get_client(opts)
@@ -709,26 +602,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetDraftResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -751,19 +631,12 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   ### Optional Arguments:
   - `parent_id`
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_draft(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   @spec delete_draft(String.t(), String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:user_id, String.t()}
-          | {:parent_id, String.t()}
+          ({:user_id, String.t()} | {:parent_id, String.t()}) | shared_opts
         ]) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_draft(type, id, opts \\ []) do
     client = get_client(opts)
@@ -783,26 +656,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -820,11 +680,17 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.FileUploadRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec upload_file(String.t(), String.t(), ExStreamClient.Model.FileUploadRequest.t()) ::
           {:ok, ExStreamClient.Model.FileUploadResponse.t()} | {:error, any()}
+  @spec upload_file(
+          String.t(),
+          String.t(),
+          ExStreamClient.Model.FileUploadRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.FileUploadResponse.t()} | {:error, any()}
   def upload_file(type, id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -838,26 +704,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.FileUploadResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -876,19 +729,12 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `id`
   ### Optional Arguments:
   - `url`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_file(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
-  @spec delete_file(String.t(), String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:url, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec delete_file(String.t(), String.t(), [{:url, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_file(type, id, opts \\ []) do
     client = get_client(opts)
 
@@ -907,26 +753,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -948,10 +781,12 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.MarkReadRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec mark_read(String.t(), String.t(), ExStreamClient.Model.MarkReadRequest.t()) ::
+          {:ok, ExStreamClient.Model.MarkReadResponse.t()} | {:error, any()}
+  @spec mark_read(String.t(), String.t(), ExStreamClient.Model.MarkReadRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.MarkReadResponse.t()} | {:error, any()}
   def mark_read(type, id, payload, opts \\ []) do
     client = get_client(opts)
@@ -966,26 +801,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.MarkReadResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -1003,11 +825,17 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.ImageUploadRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec upload_image(String.t(), String.t(), ExStreamClient.Model.ImageUploadRequest.t()) ::
           {:ok, ExStreamClient.Model.ImageUploadResponse.t()} | {:error, any()}
+  @spec upload_image(
+          String.t(),
+          String.t(),
+          ExStreamClient.Model.ImageUploadRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.ImageUploadResponse.t()} | {:error, any()}
   def upload_image(type, id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -1021,26 +849,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.ImageUploadResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -1059,19 +874,12 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `id`
   ### Optional Arguments:
   - `url`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_image(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
-  @spec delete_image(String.t(), String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:url, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec delete_image(String.t(), String.t(), [{:url, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_image(type, id, opts \\ []) do
     client = get_client(opts)
 
@@ -1090,26 +898,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -1133,12 +928,17 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   ### Required Arguments:
   - `type`
   - `payload`: `Elixir.ExStreamClient.Model.ChannelGetOrCreateRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_or_create_distinct_channel(
           String.t(),
           ExStreamClient.Model.ChannelGetOrCreateRequest.t()
+        ) :: {:ok, ExStreamClient.Model.ChannelStateResponse.t()} | {:error, any()}
+  @spec get_or_create_distinct_channel(
+          String.t(),
+          ExStreamClient.Model.ChannelGetOrCreateRequest.t(),
+          shared_opts
         ) :: {:ok, ExStreamClient.Model.ChannelStateResponse.t()} | {:error, any()}
   def get_or_create_distinct_channel(type, payload, opts \\ []) do
     client = get_client(opts)
@@ -1152,26 +952,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.ChannelStateResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -1201,11 +988,17 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.UpdateChannelRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_channel(String.t(), String.t(), ExStreamClient.Model.UpdateChannelRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateChannelResponse.t()} | {:error, any()}
+  @spec update_channel(
+          String.t(),
+          String.t(),
+          ExStreamClient.Model.UpdateChannelRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.UpdateChannelResponse.t()} | {:error, any()}
   def update_channel(type, id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -1218,26 +1011,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UpdateChannelResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -1259,13 +1039,19 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `type`
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.UpdateChannelPartialRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_channel_partial(
           String.t(),
           String.t(),
           ExStreamClient.Model.UpdateChannelPartialRequest.t()
+        ) :: {:ok, ExStreamClient.Model.UpdateChannelPartialResponse.t()} | {:error, any()}
+  @spec update_channel_partial(
+          String.t(),
+          String.t(),
+          ExStreamClient.Model.UpdateChannelPartialRequest.t(),
+          shared_opts
         ) :: {:ok, ExStreamClient.Model.UpdateChannelPartialResponse.t()} | {:error, any()}
   def update_channel_partial(type, id, payload, opts \\ []) do
     client = get_client(opts)
@@ -1279,26 +1065,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.UpdateChannelPartialResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -1321,19 +1094,12 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   - `id`
   ### Optional Arguments:
   - `hard_delete`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_channel(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.DeleteChannelResponse.t()} | {:error, any()}
-  @spec delete_channel(String.t(), String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:hard_delete, boolean()}
-        ]) :: {:ok, ExStreamClient.Model.DeleteChannelResponse.t()} | {:error, any()}
+  @spec delete_channel(String.t(), String.t(), [{:hard_delete, boolean()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.DeleteChannelResponse.t()} | {:error, any()}
   def delete_channel(type, id, opts \\ []) do
     client = get_client(opts)
 
@@ -1352,26 +1118,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.DeleteChannelResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -1391,10 +1144,12 @@ defmodule ExStreamClient.Operations.Chat.Channels do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.DeleteChannelsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_channels(ExStreamClient.Model.DeleteChannelsRequest.t()) ::
+          {:ok, ExStreamClient.Model.DeleteChannelsResponse.t()} | {:error, any()}
+  @spec delete_channels(ExStreamClient.Model.DeleteChannelsRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.DeleteChannelsResponse.t()} | {:error, any()}
   def delete_channels(payload, opts \\ []) do
     client = get_client(opts)
@@ -1408,26 +1163,13 @@ defmodule ExStreamClient.Operations.Chat.Channels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.DeleteChannelsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -1446,6 +1188,21 @@ defmodule ExStreamClient.Operations.Chat.Channels do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/chat/channeltypes.ex
+++ b/lib/ex_stream_client/operations/chat/channeltypes.ex
@@ -16,6 +16,13 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Updates channel type
 
@@ -23,11 +30,16 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
   ### Required Arguments:
   - `name`
   - `payload`: `Elixir.ExStreamClient.Model.UpdateChannelTypeRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_channel_type(String.t(), ExStreamClient.Model.UpdateChannelTypeRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateChannelTypeResponse.t()} | {:error, any()}
+  @spec update_channel_type(
+          String.t(),
+          ExStreamClient.Model.UpdateChannelTypeRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.UpdateChannelTypeResponse.t()} | {:error, any()}
   def update_channel_type(name, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -40,26 +52,13 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UpdateChannelTypeResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -75,10 +74,12 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
 
   ### Required Arguments:
   - `name`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_channel_type(String.t()) ::
+          {:ok, ExStreamClient.Model.GetChannelTypeResponse.t()} | {:error, any()}
+  @spec get_channel_type(String.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.GetChannelTypeResponse.t()} | {:error, any()}
   def get_channel_type(name, opts \\ []) do
     client = get_client(opts)
@@ -89,26 +90,13 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetChannelTypeResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -124,10 +112,12 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
 
   ### Required Arguments:
   - `name`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_channel_type(String.t()) ::
+          {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec delete_channel_type(String.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_channel_type(name, opts \\ []) do
     client = get_client(opts)
@@ -138,26 +128,13 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -173,10 +150,12 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CreateChannelTypeRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec create_channel_type(ExStreamClient.Model.CreateChannelTypeRequest.t()) ::
+          {:ok, ExStreamClient.Model.CreateChannelTypeResponse.t()} | {:error, any()}
+  @spec create_channel_type(ExStreamClient.Model.CreateChannelTypeRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CreateChannelTypeResponse.t()} | {:error, any()}
   def create_channel_type(payload, opts \\ []) do
     client = get_client(opts)
@@ -190,26 +169,13 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CreateChannelTypeResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -223,10 +189,12 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
   Lists all available channel types
 
 
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec list_channel_types() ::
+          {:ok, ExStreamClient.Model.ListChannelTypesResponse.t()} | {:error, any()}
+  @spec list_channel_types(shared_opts) ::
           {:ok, ExStreamClient.Model.ListChannelTypesResponse.t()} | {:error, any()}
   def list_channel_types(opts \\ []) do
     client = get_client(opts)
@@ -237,26 +205,13 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.ListChannelTypesResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -275,6 +230,21 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/chat/commands.ex
+++ b/lib/ex_stream_client/operations/chat/commands.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.Chat.Commands do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Creates custom chat command
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CreateCommandRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec create_command(ExStreamClient.Model.CreateCommandRequest.t()) ::
+          {:ok, ExStreamClient.Model.CreateCommandResponse.t()} | {:error, any()}
+  @spec create_command(ExStreamClient.Model.CreateCommandRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CreateCommandResponse.t()} | {:error, any()}
   def create_command(payload, opts \\ []) do
     client = get_client(opts)
@@ -36,26 +45,13 @@ defmodule ExStreamClient.Operations.Chat.Commands do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CreateCommandResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -69,10 +65,12 @@ defmodule ExStreamClient.Operations.Chat.Commands do
   Returns all custom commands
 
 
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec list_commands() :: {:ok, ExStreamClient.Model.ListCommandsResponse.t()} | {:error, any()}
+  @spec list_commands(shared_opts) ::
+          {:ok, ExStreamClient.Model.ListCommandsResponse.t()} | {:error, any()}
   def list_commands(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/commands", method: :get, params: []] ++ []
@@ -82,26 +80,13 @@ defmodule ExStreamClient.Operations.Chat.Commands do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.ListCommandsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -118,10 +103,12 @@ defmodule ExStreamClient.Operations.Chat.Commands do
   ### Required Arguments:
   - `name`
   - `payload`: `Elixir.ExStreamClient.Model.UpdateCommandRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_command(String.t(), ExStreamClient.Model.UpdateCommandRequest.t()) ::
+          {:ok, ExStreamClient.Model.UpdateCommandResponse.t()} | {:error, any()}
+  @spec update_command(String.t(), ExStreamClient.Model.UpdateCommandRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.UpdateCommandResponse.t()} | {:error, any()}
   def update_command(name, payload, opts \\ []) do
     client = get_client(opts)
@@ -135,26 +122,13 @@ defmodule ExStreamClient.Operations.Chat.Commands do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UpdateCommandResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -170,10 +144,12 @@ defmodule ExStreamClient.Operations.Chat.Commands do
 
   ### Required Arguments:
   - `name`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_command(String.t()) ::
+          {:ok, ExStreamClient.Model.GetCommandResponse.t()} | {:error, any()}
+  @spec get_command(String.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.GetCommandResponse.t()} | {:error, any()}
   def get_command(name, opts \\ []) do
     client = get_client(opts)
@@ -184,26 +160,13 @@ defmodule ExStreamClient.Operations.Chat.Commands do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetCommandResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -219,10 +182,12 @@ defmodule ExStreamClient.Operations.Chat.Commands do
 
   ### Required Arguments:
   - `name`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_command(String.t()) ::
+          {:ok, ExStreamClient.Model.DeleteCommandResponse.t()} | {:error, any()}
+  @spec delete_command(String.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.DeleteCommandResponse.t()} | {:error, any()}
   def delete_command(name, opts \\ []) do
     client = get_client(opts)
@@ -233,26 +198,13 @@ defmodule ExStreamClient.Operations.Chat.Commands do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.DeleteCommandResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -271,6 +223,21 @@ defmodule ExStreamClient.Operations.Chat.Commands do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/chat/drafts.ex
+++ b/lib/ex_stream_client/operations/chat/drafts.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.Chat.Drafts do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Queries draft messages for a user
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.QueryDraftsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_drafts(ExStreamClient.Model.QueryDraftsRequest.t()) ::
+          {:ok, ExStreamClient.Model.QueryDraftsResponse.t()} | {:error, any()}
+  @spec query_drafts(ExStreamClient.Model.QueryDraftsRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.QueryDraftsResponse.t()} | {:error, any()}
   def query_drafts(payload, opts \\ []) do
     client = get_client(opts)
@@ -39,26 +48,13 @@ defmodule ExStreamClient.Operations.Chat.Drafts do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QueryDraftsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -77,6 +73,21 @@ defmodule ExStreamClient.Operations.Chat.Drafts do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/chat/export_channels.ex
+++ b/lib/ex_stream_client/operations/chat/export_channels.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.Chat.ExportChannels do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Exports channel data to JSON file
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.ExportChannelsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec export_channels(ExStreamClient.Model.ExportChannelsRequest.t()) ::
+          {:ok, ExStreamClient.Model.ExportChannelsResponse.t()} | {:error, any()}
+  @spec export_channels(ExStreamClient.Model.ExportChannelsRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.ExportChannelsResponse.t()} | {:error, any()}
   def export_channels(payload, opts \\ []) do
     client = get_client(opts)
@@ -39,26 +48,13 @@ defmodule ExStreamClient.Operations.Chat.ExportChannels do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.ExportChannelsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -77,6 +73,21 @@ defmodule ExStreamClient.Operations.Chat.ExportChannels do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/chat/messages.ex
+++ b/lib/ex_stream_client/operations/chat/messages.ex
@@ -16,6 +16,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Delete a vote from a poll
 
@@ -29,18 +36,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   - `vote_id`
   ### Optional Arguments:
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec remove_poll_vote(String.t(), String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.PollVoteResponse.t()} | {:error, any()}
   @spec remove_poll_vote(String.t(), String.t(), String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:user_id, String.t()}
+          {:user_id, String.t()} | shared_opts
         ]) :: {:ok, ExStreamClient.Model.PollVoteResponse.t()} | {:error, any()}
   def remove_poll_vote(message_id, poll_id, vote_id, opts \\ []) do
     client = get_client(opts)
@@ -60,26 +61,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.PollVoteResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -101,19 +89,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   - `type`
   ### Optional Arguments:
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_reaction(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.DeleteReactionResponse.t()} | {:error, any()}
-  @spec delete_reaction(String.t(), String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:user_id, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.DeleteReactionResponse.t()} | {:error, any()}
+  @spec delete_reaction(String.t(), String.t(), [{:user_id, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.DeleteReactionResponse.t()} | {:error, any()}
   def delete_reaction(id, type, opts \\ []) do
     client = get_client(opts)
 
@@ -132,26 +113,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.DeleteReactionResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -172,10 +140,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.SendReactionRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec send_reaction(String.t(), ExStreamClient.Model.SendReactionRequest.t()) ::
+          {:ok, ExStreamClient.Model.SendReactionResponse.t()} | {:error, any()}
+  @spec send_reaction(String.t(), ExStreamClient.Model.SendReactionRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.SendReactionResponse.t()} | {:error, any()}
   def send_reaction(id, payload, opts \\ []) do
     client = get_client(opts)
@@ -189,26 +159,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.SendReactionResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -229,10 +186,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.MessageActionRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec run_message_action(String.t(), ExStreamClient.Model.MessageActionRequest.t()) ::
+          {:ok, ExStreamClient.Model.MessageResponse.t()} | {:error, any()}
+  @spec run_message_action(String.t(), ExStreamClient.Model.MessageActionRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.MessageResponse.t()} | {:error, any()}
   def run_message_action(id, payload, opts \\ []) do
     client = get_client(opts)
@@ -246,26 +205,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.MessageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -281,10 +227,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.QueryMessageHistoryRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_message_history(ExStreamClient.Model.QueryMessageHistoryRequest.t()) ::
+          {:ok, ExStreamClient.Model.QueryMessageHistoryResponse.t()} | {:error, any()}
+  @spec query_message_history(ExStreamClient.Model.QueryMessageHistoryRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.QueryMessageHistoryResponse.t()} | {:error, any()}
   def query_message_history(payload, opts \\ []) do
     client = get_client(opts)
@@ -298,26 +246,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QueryMessageHistoryResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -338,11 +273,17 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   - `message_id`
   - `poll_id`
   - `payload`: `Elixir.ExStreamClient.Model.CastPollVoteRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec cast_poll_vote(String.t(), String.t(), ExStreamClient.Model.CastPollVoteRequest.t()) ::
           {:ok, ExStreamClient.Model.PollVoteResponse.t()} | {:error, any()}
+  @spec cast_poll_vote(
+          String.t(),
+          String.t(),
+          ExStreamClient.Model.CastPollVoteRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.PollVoteResponse.t()} | {:error, any()}
   def cast_poll_vote(message_id, poll_id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -359,26 +300,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.PollVoteResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -395,10 +323,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.QueryReactionsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_reactions(String.t(), ExStreamClient.Model.QueryReactionsRequest.t()) ::
+          {:ok, ExStreamClient.Model.QueryReactionsResponse.t()} | {:error, any()}
+  @spec query_reactions(String.t(), ExStreamClient.Model.QueryReactionsRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.QueryReactionsResponse.t()} | {:error, any()}
   def query_reactions(id, payload, opts \\ []) do
     client = get_client(opts)
@@ -412,26 +342,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QueryReactionsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -450,20 +367,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   ### Optional Arguments:
   - `limit`
   - `offset`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_reactions(String.t()) ::
           {:ok, ExStreamClient.Model.GetReactionsResponse.t()} | {:error, any()}
-  @spec get_reactions(String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:offset, integer()}
-          | {:limit, integer()}
-        ]) :: {:ok, ExStreamClient.Model.GetReactionsResponse.t()} | {:error, any()}
+  @spec get_reactions(String.t(), [({:offset, integer()} | {:limit, integer()}) | shared_opts]) ::
+          {:ok, ExStreamClient.Model.GetReactionsResponse.t()} | {:error, any()}
   def get_reactions(id, opts \\ []) do
     client = get_client(opts)
 
@@ -482,26 +391,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetReactionsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -531,30 +427,25 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   - `limit`
   - `offset`
   - `sort`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_replies(String.t()) ::
           {:ok, ExStreamClient.Model.GetRepliesResponse.t()} | {:error, any()}
   @spec get_replies(String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:created_at_around, float()}
-          | {:id_around, String.t()}
-          | {:created_at_before, float()}
-          | {:created_at_before_or_equal, float()}
-          | {:created_at_after, float()}
-          | {:created_at_after_or_equal, float()}
-          | {:id_lt, String.t()}
-          | {:id_lte, String.t()}
-          | {:id_gt, String.t()}
-          | {:id_gte, String.t()}
-          | {:offset, integer()}
-          | {:limit, integer()}
-          | {:sort, list()}
+          ({:created_at_around, float()}
+           | {:id_around, String.t()}
+           | {:created_at_before, float()}
+           | {:created_at_before_or_equal, float()}
+           | {:created_at_after, float()}
+           | {:created_at_after_or_equal, float()}
+           | {:id_lt, String.t()}
+           | {:id_lte, String.t()}
+           | {:id_gt, String.t()}
+           | {:id_gte, String.t()}
+           | {:offset, integer()}
+           | {:limit, integer()}
+           | {:sort, list()})
+          | shared_opts
         ]) :: {:ok, ExStreamClient.Model.GetRepliesResponse.t()} | {:error, any()}
   def get_replies(parent_id, opts \\ []) do
     client = get_client(opts)
@@ -591,26 +482,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetRepliesResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -631,10 +509,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.UpdateMessageRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec undelete_message(String.t(), ExStreamClient.Model.UpdateMessageRequest.t()) ::
+          {:ok, ExStreamClient.Model.UpdateMessageResponse.t()} | {:error, any()}
+  @spec undelete_message(String.t(), ExStreamClient.Model.UpdateMessageRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.UpdateMessageResponse.t()} | {:error, any()}
   def undelete_message(id, payload, opts \\ []) do
     client = get_client(opts)
@@ -648,26 +528,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UpdateMessageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -688,11 +555,16 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.TranslateMessageRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec translate_message(String.t(), ExStreamClient.Model.TranslateMessageRequest.t()) ::
           {:ok, ExStreamClient.Model.MessageResponse.t()} | {:error, any()}
+  @spec translate_message(
+          String.t(),
+          ExStreamClient.Model.TranslateMessageRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.MessageResponse.t()} | {:error, any()}
   def translate_message(id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -705,26 +577,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.MessageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -747,10 +606,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.CommitMessageRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec commit_message(String.t(), ExStreamClient.Model.CommitMessageRequest.t()) ::
+          {:ok, ExStreamClient.Model.MessageResponse.t()} | {:error, any()}
+  @spec commit_message(String.t(), ExStreamClient.Model.CommitMessageRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.MessageResponse.t()} | {:error, any()}
   def commit_message(id, payload, opts \\ []) do
     client = get_client(opts)
@@ -764,26 +625,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.MessageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -804,11 +652,16 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.UpdateMessagePartialRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_message_partial(String.t(), ExStreamClient.Model.UpdateMessagePartialRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateMessagePartialResponse.t()} | {:error, any()}
+  @spec update_message_partial(
+          String.t(),
+          ExStreamClient.Model.UpdateMessagePartialRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.UpdateMessagePartialResponse.t()} | {:error, any()}
   def update_message_partial(id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -821,26 +674,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UpdateMessagePartialResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -861,10 +701,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.UpdateMessageRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_message(String.t(), ExStreamClient.Model.UpdateMessageRequest.t()) ::
+          {:ok, ExStreamClient.Model.UpdateMessageResponse.t()} | {:error, any()}
+  @spec update_message(String.t(), ExStreamClient.Model.UpdateMessageRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.UpdateMessageResponse.t()} | {:error, any()}
   def update_message(id, payload, opts \\ []) do
     client = get_client(opts)
@@ -878,26 +720,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UpdateMessageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -915,19 +744,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   - `id`
   ### Optional Arguments:
   - `show_deleted_message`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_message(String.t()) ::
           {:ok, ExStreamClient.Model.GetMessageResponse.t()} | {:error, any()}
-  @spec get_message(String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:show_deleted_message, boolean()}
-        ]) :: {:ok, ExStreamClient.Model.GetMessageResponse.t()} | {:error, any()}
+  @spec get_message(String.t(), [{:show_deleted_message, boolean()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.GetMessageResponse.t()} | {:error, any()}
   def get_message(id, opts \\ []) do
     client = get_client(opts)
 
@@ -946,26 +768,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetMessageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -988,19 +797,12 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   ### Optional Arguments:
   - `deleted_by`
   - `hard`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_message(String.t()) ::
           {:ok, ExStreamClient.Model.DeleteMessageResponse.t()} | {:error, any()}
   @spec delete_message(String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:deleted_by, String.t()}
-          | {:hard, boolean()}
+          ({:deleted_by, String.t()} | {:hard, boolean()}) | shared_opts
         ]) :: {:ok, ExStreamClient.Model.DeleteMessageResponse.t()} | {:error, any()}
   def delete_message(id, opts \\ []) do
     client = get_client(opts)
@@ -1020,26 +822,13 @@ defmodule ExStreamClient.Operations.Chat.Messages do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.DeleteMessageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -1058,6 +847,21 @@ defmodule ExStreamClient.Operations.Chat.Messages do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/chat/moderation.ex
+++ b/lib/ex_stream_client/operations/chat/moderation.ex
@@ -16,24 +16,25 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Find and filter message flags
 
 
   ### Optional Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.QueryMessageFlagsPayload`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_message_flags() ::
           {:ok, ExStreamClient.Model.QueryMessageFlagsResponse.t()} | {:error, any()}
   @spec query_message_flags([
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:payload, ExStreamClient.Model.QueryMessageFlagsPayload.t()}
+          {:payload, ExStreamClient.Model.QueryMessageFlagsPayload.t()} | shared_opts
         ]) :: {:ok, ExStreamClient.Model.QueryMessageFlagsResponse.t()} | {:error, any()}
   def query_message_flags(opts \\ []) do
     client = get_client(opts)
@@ -53,26 +54,13 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.QueryMessageFlagsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -92,10 +80,12 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.UnmuteChannelRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec unmute_channel(ExStreamClient.Model.UnmuteChannelRequest.t()) ::
+          {:ok, ExStreamClient.Model.UnmuteResponse.t()} | {:error, any()}
+  @spec unmute_channel(ExStreamClient.Model.UnmuteChannelRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.UnmuteResponse.t()} | {:error, any()}
   def unmute_channel(payload, opts \\ []) do
     client = get_client(opts)
@@ -110,26 +100,13 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UnmuteResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -149,10 +126,12 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.MuteChannelRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec mute_channel(ExStreamClient.Model.MuteChannelRequest.t()) ::
+          {:ok, ExStreamClient.Model.MuteChannelResponse.t()} | {:error, any()}
+  @spec mute_channel(ExStreamClient.Model.MuteChannelRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.MuteChannelResponse.t()} | {:error, any()}
   def mute_channel(payload, opts \\ []) do
     client = get_client(opts)
@@ -166,26 +145,13 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.MuteChannelResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -204,6 +170,21 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/chat/polls.ex
+++ b/lib/ex_stream_client/operations/chat/polls.ex
@@ -16,6 +16,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Queries votes
 
@@ -25,18 +32,12 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   - `payload`: `Elixir.ExStreamClient.Model.QueryPollVotesRequest`
   ### Optional Arguments:
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_poll_votes(String.t(), ExStreamClient.Model.QueryPollVotesRequest.t()) ::
           {:ok, ExStreamClient.Model.PollVotesResponse.t()} | {:error, any()}
   @spec query_poll_votes(String.t(), ExStreamClient.Model.QueryPollVotesRequest.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:user_id, String.t()}
+          {:user_id, String.t()} | shared_opts
         ]) :: {:ok, ExStreamClient.Model.PollVotesResponse.t()} | {:error, any()}
   def query_poll_votes(poll_id, payload, opts \\ []) do
     client = get_client(opts)
@@ -56,26 +57,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.PollVotesResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -95,10 +83,12 @@ defmodule ExStreamClient.Operations.Chat.Polls do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.UpdatePollRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_poll(ExStreamClient.Model.UpdatePollRequest.t()) ::
+          {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
+  @spec update_poll(ExStreamClient.Model.UpdatePollRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
   def update_poll(payload, opts \\ []) do
     client = get_client(opts)
@@ -109,26 +99,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.PollResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -144,10 +121,12 @@ defmodule ExStreamClient.Operations.Chat.Polls do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CreatePollRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec create_poll(ExStreamClient.Model.CreatePollRequest.t()) ::
+          {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
+  @spec create_poll(ExStreamClient.Model.CreatePollRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
   def create_poll(payload, opts \\ []) do
     client = get_client(opts)
@@ -158,26 +137,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.PollResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -197,11 +163,16 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   ### Required Arguments:
   - `poll_id`
   - `payload`: `Elixir.ExStreamClient.Model.UpdatePollOptionRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_poll_option(String.t(), ExStreamClient.Model.UpdatePollOptionRequest.t()) ::
           {:ok, ExStreamClient.Model.PollOptionResponse.t()} | {:error, any()}
+  @spec update_poll_option(
+          String.t(),
+          ExStreamClient.Model.UpdatePollOptionRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.PollOptionResponse.t()} | {:error, any()}
   def update_poll_option(poll_id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -214,26 +185,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.PollOptionResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -253,11 +211,16 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   ### Required Arguments:
   - `poll_id`
   - `payload`: `Elixir.ExStreamClient.Model.CreatePollOptionRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec create_poll_option(String.t(), ExStreamClient.Model.CreatePollOptionRequest.t()) ::
           {:ok, ExStreamClient.Model.PollOptionResponse.t()} | {:error, any()}
+  @spec create_poll_option(
+          String.t(),
+          ExStreamClient.Model.CreatePollOptionRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.PollOptionResponse.t()} | {:error, any()}
   def create_poll_option(poll_id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -270,26 +233,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.PollOptionResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -309,11 +259,16 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   ### Required Arguments:
   - `poll_id`
   - `payload`: `Elixir.ExStreamClient.Model.UpdatePollPartialRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_poll_partial(String.t(), ExStreamClient.Model.UpdatePollPartialRequest.t()) ::
           {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
+  @spec update_poll_partial(
+          String.t(),
+          ExStreamClient.Model.UpdatePollPartialRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
   def update_poll_partial(poll_id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -326,26 +281,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.PollResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -363,18 +305,11 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   - `poll_id`
   ### Optional Arguments:
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_poll(String.t()) :: {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
-  @spec get_poll(String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:user_id, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
+  @spec get_poll(String.t(), [{:user_id, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.PollResponse.t()} | {:error, any()}
   def get_poll(poll_id, opts \\ []) do
     client = get_client(opts)
 
@@ -393,26 +328,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.PollResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -433,18 +355,11 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   - `poll_id`
   ### Optional Arguments:
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_poll(String.t()) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
-  @spec delete_poll(String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:user_id, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec delete_poll(String.t(), [{:user_id, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_poll(poll_id, opts \\ []) do
     client = get_client(opts)
 
@@ -463,26 +378,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -500,18 +402,12 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   - `payload`: `Elixir.ExStreamClient.Model.QueryPollsRequest`
   ### Optional Arguments:
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_polls(ExStreamClient.Model.QueryPollsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryPollsResponse.t()} | {:error, any()}
   @spec query_polls(ExStreamClient.Model.QueryPollsRequest.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:user_id, String.t()}
+          {:user_id, String.t()} | shared_opts
         ]) :: {:ok, ExStreamClient.Model.QueryPollsResponse.t()} | {:error, any()}
   def query_polls(payload, opts \\ []) do
     client = get_client(opts)
@@ -531,26 +427,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QueryPollsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -569,19 +452,12 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   - `option_id`
   ### Optional Arguments:
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_poll_option(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.PollOptionResponse.t()} | {:error, any()}
-  @spec get_poll_option(String.t(), String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:user_id, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.PollOptionResponse.t()} | {:error, any()}
+  @spec get_poll_option(String.t(), String.t(), [{:user_id, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.PollOptionResponse.t()} | {:error, any()}
   def get_poll_option(poll_id, option_id, opts \\ []) do
     client = get_client(opts)
 
@@ -600,26 +476,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.PollOptionResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -641,19 +504,12 @@ defmodule ExStreamClient.Operations.Chat.Polls do
   - `option_id`
   ### Optional Arguments:
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_poll_option(String.t(), String.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
-  @spec delete_poll_option(String.t(), String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:user_id, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec delete_poll_option(String.t(), String.t(), [{:user_id, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_poll_option(poll_id, option_id, opts \\ []) do
     client = get_client(opts)
 
@@ -672,26 +528,13 @@ defmodule ExStreamClient.Operations.Chat.Polls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -710,6 +553,21 @@ defmodule ExStreamClient.Operations.Chat.Polls do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/chat/segments.ex
+++ b/lib/ex_stream_client/operations/chat/segments.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.Chat.Segments do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Get segment
 
 
   ### Required Arguments:
   - `id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_segment(String.t()) ::
+          {:ok, ExStreamClient.Model.GetSegmentResponse.t()} | {:error, any()}
+  @spec get_segment(String.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.GetSegmentResponse.t()} | {:error, any()}
   def get_segment(id, opts \\ []) do
     client = get_client(opts)
@@ -36,26 +45,13 @@ defmodule ExStreamClient.Operations.Chat.Segments do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetSegmentResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -71,10 +67,12 @@ defmodule ExStreamClient.Operations.Chat.Segments do
 
   ### Required Arguments:
   - `id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_segment(String.t()) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec delete_segment(String.t(), shared_opts) ::
+          {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_segment(id, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/chat/segments/#{id}", method: :delete, params: []] ++ []
@@ -84,26 +82,13 @@ defmodule ExStreamClient.Operations.Chat.Segments do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -120,11 +105,16 @@ defmodule ExStreamClient.Operations.Chat.Segments do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.QuerySegmentTargetsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_segment_targets(String.t(), ExStreamClient.Model.QuerySegmentTargetsRequest.t()) ::
           {:ok, ExStreamClient.Model.QuerySegmentTargetsResponse.t()} | {:error, any()}
+  @spec query_segment_targets(
+          String.t(),
+          ExStreamClient.Model.QuerySegmentTargetsRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.QuerySegmentTargetsResponse.t()} | {:error, any()}
   def query_segment_targets(id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -138,26 +128,13 @@ defmodule ExStreamClient.Operations.Chat.Segments do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QuerySegmentTargetsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -173,10 +150,12 @@ defmodule ExStreamClient.Operations.Chat.Segments do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.QuerySegmentsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_segments(ExStreamClient.Model.QuerySegmentsRequest.t()) ::
+          {:ok, ExStreamClient.Model.QuerySegmentsResponse.t()} | {:error, any()}
+  @spec query_segments(ExStreamClient.Model.QuerySegmentsRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.QuerySegmentsResponse.t()} | {:error, any()}
   def query_segments(payload, opts \\ []) do
     client = get_client(opts)
@@ -190,26 +169,13 @@ defmodule ExStreamClient.Operations.Chat.Segments do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QuerySegmentsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -226,11 +192,16 @@ defmodule ExStreamClient.Operations.Chat.Segments do
   ### Required Arguments:
   - `id`
   - `payload`: `Elixir.ExStreamClient.Model.DeleteSegmentTargetsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_segment_targets(String.t(), ExStreamClient.Model.DeleteSegmentTargetsRequest.t()) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec delete_segment_targets(
+          String.t(),
+          ExStreamClient.Model.DeleteSegmentTargetsRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def delete_segment_targets(id, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -244,26 +215,13 @@ defmodule ExStreamClient.Operations.Chat.Segments do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -280,10 +238,12 @@ defmodule ExStreamClient.Operations.Chat.Segments do
   ### Required Arguments:
   - `id`
   - `target_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec segment_target_exists(String.t(), String.t()) ::
+          {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec segment_target_exists(String.t(), String.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def segment_target_exists(id, target_id, opts \\ []) do
     client = get_client(opts)
@@ -297,26 +257,13 @@ defmodule ExStreamClient.Operations.Chat.Segments do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -335,6 +282,21 @@ defmodule ExStreamClient.Operations.Chat.Segments do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/chat/unread_batch.ex
+++ b/lib/ex_stream_client/operations/chat/unread_batch.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.Chat.UnreadBatch do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Fetch unread counts in batch for multiple users in one call
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.UnreadCountsBatchRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec unread_counts_batch(ExStreamClient.Model.UnreadCountsBatchRequest.t()) ::
+          {:ok, ExStreamClient.Model.UnreadCountsBatchResponse.t()} | {:error, any()}
+  @spec unread_counts_batch(ExStreamClient.Model.UnreadCountsBatchRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.UnreadCountsBatchResponse.t()} | {:error, any()}
   def unread_counts_batch(payload, opts \\ []) do
     client = get_client(opts)
@@ -39,26 +48,13 @@ defmodule ExStreamClient.Operations.Chat.UnreadBatch do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UnreadCountsBatchResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -77,6 +73,21 @@ defmodule ExStreamClient.Operations.Chat.UnreadBatch do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/check_push.ex
+++ b/lib/ex_stream_client/operations/check_push.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.CheckPush do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Sends a test message via push, this is a test endpoint to verify your push settings
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CheckPushRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec check_push(ExStreamClient.Model.CheckPushRequest.t()) ::
+          {:ok, ExStreamClient.Model.CheckPushResponse.t()} | {:error, any()}
+  @spec check_push(ExStreamClient.Model.CheckPushRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CheckPushResponse.t()} | {:error, any()}
   def check_push(payload, opts \\ []) do
     client = get_client(opts)
@@ -36,26 +45,13 @@ defmodule ExStreamClient.Operations.CheckPush do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CheckPushResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -74,6 +70,21 @@ defmodule ExStreamClient.Operations.CheckPush do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/check_sns.ex
+++ b/lib/ex_stream_client/operations/check_sns.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.CheckSns do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Validates Amazon SNS configuration
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CheckSNSRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec check_sns(ExStreamClient.Model.CheckSNSRequest.t()) ::
+          {:ok, ExStreamClient.Model.CheckSNSResponse.t()} | {:error, any()}
+  @spec check_sns(ExStreamClient.Model.CheckSNSRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CheckSNSResponse.t()} | {:error, any()}
   def check_sns(payload, opts \\ []) do
     client = get_client(opts)
@@ -36,26 +45,13 @@ defmodule ExStreamClient.Operations.CheckSns do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CheckSNSResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -74,6 +70,21 @@ defmodule ExStreamClient.Operations.CheckSns do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/check_sqs.ex
+++ b/lib/ex_stream_client/operations/check_sqs.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.CheckSqs do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Validates Amazon SQS credentials
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CheckSQSRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec check_sqs(ExStreamClient.Model.CheckSQSRequest.t()) ::
+          {:ok, ExStreamClient.Model.CheckSQSResponse.t()} | {:error, any()}
+  @spec check_sqs(ExStreamClient.Model.CheckSQSRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CheckSQSResponse.t()} | {:error, any()}
   def check_sqs(payload, opts \\ []) do
     client = get_client(opts)
@@ -36,26 +45,13 @@ defmodule ExStreamClient.Operations.CheckSqs do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CheckSQSResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -74,6 +70,21 @@ defmodule ExStreamClient.Operations.CheckSqs do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/external_storage.ex
+++ b/lib/ex_stream_client/operations/external_storage.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.ExternalStorage do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
 
 
 
   ### Required Arguments:
   - `name`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec check_external_storage(String.t()) ::
+          {:ok, ExStreamClient.Model.CheckExternalStorageResponse.t()} | {:error, any()}
+  @spec check_external_storage(String.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CheckExternalStorageResponse.t()} | {:error, any()}
   def check_external_storage(name, opts \\ []) do
     client = get_client(opts)
@@ -36,26 +45,13 @@ defmodule ExStreamClient.Operations.ExternalStorage do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.CheckExternalStorageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -71,11 +67,15 @@ defmodule ExStreamClient.Operations.ExternalStorage do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CreateExternalStorageRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec create_external_storage(ExStreamClient.Model.CreateExternalStorageRequest.t()) ::
           {:ok, ExStreamClient.Model.CreateExternalStorageResponse.t()} | {:error, any()}
+  @spec create_external_storage(
+          ExStreamClient.Model.CreateExternalStorageRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.CreateExternalStorageResponse.t()} | {:error, any()}
   def create_external_storage(payload, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/external_storage", method: :post, params: []] ++ [json: payload]
@@ -85,26 +85,13 @@ defmodule ExStreamClient.Operations.ExternalStorage do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CreateExternalStorageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -118,10 +105,12 @@ defmodule ExStreamClient.Operations.ExternalStorage do
   Lists external storage
 
 
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec list_external_storage() ::
+          {:ok, ExStreamClient.Model.ListExternalStorageResponse.t()} | {:error, any()}
+  @spec list_external_storage(shared_opts) ::
           {:ok, ExStreamClient.Model.ListExternalStorageResponse.t()} | {:error, any()}
   def list_external_storage(opts \\ []) do
     client = get_client(opts)
@@ -132,26 +121,13 @@ defmodule ExStreamClient.Operations.ExternalStorage do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.ListExternalStorageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -168,11 +144,16 @@ defmodule ExStreamClient.Operations.ExternalStorage do
   ### Required Arguments:
   - `name`
   - `payload`: `Elixir.ExStreamClient.Model.UpdateExternalStorageRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_external_storage(String.t(), ExStreamClient.Model.UpdateExternalStorageRequest.t()) ::
           {:ok, ExStreamClient.Model.UpdateExternalStorageResponse.t()} | {:error, any()}
+  @spec update_external_storage(
+          String.t(),
+          ExStreamClient.Model.UpdateExternalStorageRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.UpdateExternalStorageResponse.t()} | {:error, any()}
   def update_external_storage(name, payload, opts \\ []) do
     client = get_client(opts)
 
@@ -185,26 +166,13 @@ defmodule ExStreamClient.Operations.ExternalStorage do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UpdateExternalStorageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -220,10 +188,12 @@ defmodule ExStreamClient.Operations.ExternalStorage do
 
   ### Required Arguments:
   - `name`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_external_storage(String.t()) ::
+          {:ok, ExStreamClient.Model.DeleteExternalStorageResponse.t()} | {:error, any()}
+  @spec delete_external_storage(String.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.DeleteExternalStorageResponse.t()} | {:error, any()}
   def delete_external_storage(name, opts \\ []) do
     client = get_client(opts)
@@ -234,26 +204,13 @@ defmodule ExStreamClient.Operations.ExternalStorage do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.DeleteExternalStorageResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -272,6 +229,21 @@ defmodule ExStreamClient.Operations.ExternalStorage do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/guest.ex
+++ b/lib/ex_stream_client/operations/guest.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.Guest do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
 
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CreateGuestRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec create_guest(ExStreamClient.Model.CreateGuestRequest.t()) ::
+          {:ok, ExStreamClient.Model.CreateGuestResponse.t()} | {:error, any()}
+  @spec create_guest(ExStreamClient.Model.CreateGuestRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CreateGuestResponse.t()} | {:error, any()}
   def create_guest(payload, opts \\ []) do
     client = get_client(opts)
@@ -36,26 +45,13 @@ defmodule ExStreamClient.Operations.Guest do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CreateGuestResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -74,6 +70,21 @@ defmodule ExStreamClient.Operations.Guest do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/import_urls.ex
+++ b/lib/ex_stream_client/operations/import_urls.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.ImportUrls do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Creates a new import URL
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CreateImportURLRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec create_import_url(ExStreamClient.Model.CreateImportURLRequest.t()) ::
+          {:ok, ExStreamClient.Model.CreateImportURLResponse.t()} | {:error, any()}
+  @spec create_import_url(ExStreamClient.Model.CreateImportURLRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CreateImportURLResponse.t()} | {:error, any()}
   def create_import_url(payload, opts \\ []) do
     client = get_client(opts)
@@ -36,26 +45,13 @@ defmodule ExStreamClient.Operations.ImportUrls do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CreateImportURLResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -74,6 +70,21 @@ defmodule ExStreamClient.Operations.ImportUrls do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/imports.ex
+++ b/lib/ex_stream_client/operations/imports.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.Imports do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Gets an import
 
 
   ### Required Arguments:
   - `id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_import(String.t()) ::
+          {:ok, ExStreamClient.Model.GetImportResponse.t()} | {:error, any()}
+  @spec get_import(String.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.GetImportResponse.t()} | {:error, any()}
   def get_import(id, opts \\ []) do
     client = get_client(opts)
@@ -36,26 +45,13 @@ defmodule ExStreamClient.Operations.Imports do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetImportResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -71,10 +67,12 @@ defmodule ExStreamClient.Operations.Imports do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CreateImportRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec create_import(ExStreamClient.Model.CreateImportRequest.t()) ::
+          {:ok, ExStreamClient.Model.CreateImportResponse.t()} | {:error, any()}
+  @spec create_import(ExStreamClient.Model.CreateImportRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CreateImportResponse.t()} | {:error, any()}
   def create_import(payload, opts \\ []) do
     client = get_client(opts)
@@ -85,26 +83,13 @@ defmodule ExStreamClient.Operations.Imports do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CreateImportResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -118,10 +103,12 @@ defmodule ExStreamClient.Operations.Imports do
   Gets an import
 
 
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec list_imports() :: {:ok, ExStreamClient.Model.ListImportsResponse.t()} | {:error, any()}
+  @spec list_imports(shared_opts) ::
+          {:ok, ExStreamClient.Model.ListImportsResponse.t()} | {:error, any()}
   def list_imports(opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/imports", method: :get, params: []] ++ []
@@ -131,26 +118,13 @@ defmodule ExStreamClient.Operations.Imports do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.ListImportsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -169,6 +143,21 @@ defmodule ExStreamClient.Operations.Imports do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/moderation.ex
+++ b/lib/ex_stream_client/operations/moderation.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.Moderation do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Custom check, add your own AI model reports to the review queue
 
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CustomCheckRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec custom_check(ExStreamClient.Model.CustomCheckRequest.t()) ::
+          {:ok, ExStreamClient.Model.CustomCheckResponse.t()} | {:error, any()}
+  @spec custom_check(ExStreamClient.Model.CustomCheckRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CustomCheckResponse.t()} | {:error, any()}
   def custom_check(payload, opts \\ []) do
     client = get_client(opts)
@@ -39,26 +48,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CustomCheckResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -78,19 +74,12 @@ defmodule ExStreamClient.Operations.Moderation do
   ### Optional Arguments:
   - `channel_cid`
   - `created_by`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec unban(String.t(), ExStreamClient.Model.UnbanRequest.t()) ::
           {:ok, ExStreamClient.Model.UnbanResponse.t()} | {:error, any()}
   @spec unban(String.t(), ExStreamClient.Model.UnbanRequest.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:created_by, String.t()}
-          | {:channel_cid, String.t()}
+          ({:created_by, String.t()} | {:channel_cid, String.t()}) | shared_opts
         ]) :: {:ok, ExStreamClient.Model.UnbanResponse.t()} | {:error, any()}
   def unban(target_user_id, payload, opts \\ []) do
     client = get_client(opts)
@@ -113,26 +102,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UnbanResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -148,10 +124,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.SubmitActionRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec submit_action(ExStreamClient.Model.SubmitActionRequest.t()) ::
+          {:ok, ExStreamClient.Model.SubmitActionResponse.t()} | {:error, any()}
+  @spec submit_action(ExStreamClient.Model.SubmitActionRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.SubmitActionResponse.t()} | {:error, any()}
   def submit_action(payload, opts \\ []) do
     client = get_client(opts)
@@ -165,26 +143,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.SubmitActionResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -200,10 +165,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.UnmuteRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec unmute(ExStreamClient.Model.UnmuteRequest.t()) ::
+          {:ok, ExStreamClient.Model.UnmuteResponse.t()} | {:error, any()}
+  @spec unmute(ExStreamClient.Model.UnmuteRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.UnmuteResponse.t()} | {:error, any()}
   def unmute(payload, opts \\ []) do
     client = get_client(opts)
@@ -217,26 +184,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UnmuteResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -252,11 +206,15 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.QueryModerationConfigsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_moderation_configs(ExStreamClient.Model.QueryModerationConfigsRequest.t()) ::
           {:ok, ExStreamClient.Model.QueryModerationConfigsResponse.t()} | {:error, any()}
+  @spec query_moderation_configs(
+          ExStreamClient.Model.QueryModerationConfigsRequest.t(),
+          shared_opts
+        ) :: {:ok, ExStreamClient.Model.QueryModerationConfigsResponse.t()} | {:error, any()}
   def query_moderation_configs(payload, opts \\ []) do
     client = get_client(opts)
 
@@ -269,26 +227,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QueryModerationConfigsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -304,10 +249,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_review_queue_item(String.t()) ::
+          {:ok, ExStreamClient.Model.GetReviewQueueItemResponse.t()} | {:error, any()}
+  @spec get_review_queue_item(String.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.GetReviewQueueItemResponse.t()} | {:error, any()}
   def get_review_queue_item(id, opts \\ []) do
     client = get_client(opts)
@@ -318,26 +265,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetReviewQueueItemResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -353,10 +287,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.BulkImageModerationRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec bulk_image_moderation(ExStreamClient.Model.BulkImageModerationRequest.t()) ::
+          {:ok, ExStreamClient.Model.BulkImageModerationResponse.t()} | {:error, any()}
+  @spec bulk_image_moderation(ExStreamClient.Model.BulkImageModerationRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.BulkImageModerationResponse.t()} | {:error, any()}
   def bulk_image_moderation(payload, opts \\ []) do
     client = get_client(opts)
@@ -371,26 +307,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.BulkImageModerationResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -406,10 +329,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.QueryModerationLogsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_moderation_logs(ExStreamClient.Model.QueryModerationLogsRequest.t()) ::
+          {:ok, ExStreamClient.Model.QueryModerationLogsResponse.t()} | {:error, any()}
+  @spec query_moderation_logs(ExStreamClient.Model.QueryModerationLogsRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.QueryModerationLogsResponse.t()} | {:error, any()}
   def query_moderation_logs(payload, opts \\ []) do
     client = get_client(opts)
@@ -420,26 +345,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QueryModerationLogsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -455,10 +367,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.UpsertModerationTemplateRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec v2_upsert_template(ExStreamClient.Model.UpsertModerationTemplateRequest.t()) ::
+          {:ok, ExStreamClient.Model.UpsertModerationTemplateResponse.t()} | {:error, any()}
+  @spec v2_upsert_template(ExStreamClient.Model.UpsertModerationTemplateRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.UpsertModerationTemplateResponse.t()} | {:error, any()}
   def v2_upsert_template(payload, opts \\ []) do
     client = get_client(opts)
@@ -473,26 +387,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UpsertModerationTemplateResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -506,10 +407,12 @@ defmodule ExStreamClient.Operations.Moderation do
   Retrieve a list of feed moderation templates that define preset moderation rules and configurations. Limited to 100 templates per request.
 
 
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec v2_query_templates() ::
+          {:ok, ExStreamClient.Model.QueryFeedModerationTemplatesResponse.t()} | {:error, any()}
+  @spec v2_query_templates(shared_opts) ::
           {:ok, ExStreamClient.Model.QueryFeedModerationTemplatesResponse.t()} | {:error, any()}
   def v2_query_templates(opts \\ []) do
     client = get_client(opts)
@@ -523,26 +426,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.QueryFeedModerationTemplatesResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -556,10 +446,12 @@ defmodule ExStreamClient.Operations.Moderation do
   Delete a specific moderation template by its name
 
 
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec v2_delete_template() ::
+          {:ok, ExStreamClient.Model.DeleteModerationTemplateResponse.t()} | {:error, any()}
+  @spec v2_delete_template(shared_opts) ::
           {:ok, ExStreamClient.Model.DeleteModerationTemplateResponse.t()} | {:error, any()}
   def v2_delete_template(opts \\ []) do
     client = get_client(opts)
@@ -573,26 +465,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.DeleteModerationTemplateResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -608,10 +487,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.MuteRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec mute(ExStreamClient.Model.MuteRequest.t()) ::
+          {:ok, ExStreamClient.Model.MuteResponse.t()} | {:error, any()}
+  @spec mute(ExStreamClient.Model.MuteRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.MuteResponse.t()} | {:error, any()}
   def mute(payload, opts \\ []) do
     client = get_client(opts)
@@ -622,26 +503,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.MuteResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -657,10 +525,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.BanRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec ban(ExStreamClient.Model.BanRequest.t()) ::
+          {:ok, ExStreamClient.Model.BanResponse.t()} | {:error, any()}
+  @spec ban(ExStreamClient.Model.BanRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.BanResponse.t()} | {:error, any()}
   def ban(payload, opts \\ []) do
     client = get_client(opts)
@@ -671,26 +541,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.BanResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -706,10 +563,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.UpsertConfigRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec upsert_config(ExStreamClient.Model.UpsertConfigRequest.t()) ::
+          {:ok, ExStreamClient.Model.UpsertConfigResponse.t()} | {:error, any()}
+  @spec upsert_config(ExStreamClient.Model.UpsertConfigRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.UpsertConfigResponse.t()} | {:error, any()}
   def upsert_config(payload, opts \\ []) do
     client = get_client(opts)
@@ -723,26 +582,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UpsertConfigResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -758,10 +604,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.QueryReviewQueueRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_review_queue(ExStreamClient.Model.QueryReviewQueueRequest.t()) ::
+          {:ok, ExStreamClient.Model.QueryReviewQueueResponse.t()} | {:error, any()}
+  @spec query_review_queue(ExStreamClient.Model.QueryReviewQueueRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.QueryReviewQueueResponse.t()} | {:error, any()}
   def query_review_queue(payload, opts \\ []) do
     client = get_client(opts)
@@ -775,26 +623,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QueryReviewQueueResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -812,19 +647,12 @@ defmodule ExStreamClient.Operations.Moderation do
   - `key`
   ### Optional Arguments:
   - `team`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_config(String.t()) ::
           {:ok, ExStreamClient.Model.GetConfigResponse.t()} | {:error, any()}
-  @spec get_config(String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:team, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.GetConfigResponse.t()} | {:error, any()}
+  @spec get_config(String.t(), [{:team, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.GetConfigResponse.t()} | {:error, any()}
   def get_config(key, opts \\ []) do
     client = get_client(opts)
 
@@ -843,26 +671,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetConfigResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -880,19 +695,12 @@ defmodule ExStreamClient.Operations.Moderation do
   - `key`
   ### Optional Arguments:
   - `team`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_config(String.t()) ::
           {:ok, ExStreamClient.Model.DeleteModerationConfigResponse.t()} | {:error, any()}
-  @spec delete_config(String.t(), [
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:team, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.DeleteModerationConfigResponse.t()} | {:error, any()}
+  @spec delete_config(String.t(), [{:team, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.DeleteModerationConfigResponse.t()} | {:error, any()}
   def delete_config(key, opts \\ []) do
     client = get_client(opts)
 
@@ -911,26 +719,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.DeleteModerationConfigResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -946,10 +741,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.QueryModerationFlagsRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_moderation_flags(ExStreamClient.Model.QueryModerationFlagsRequest.t()) ::
+          {:ok, ExStreamClient.Model.QueryModerationFlagsResponse.t()} | {:error, any()}
+  @spec query_moderation_flags(ExStreamClient.Model.QueryModerationFlagsRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.QueryModerationFlagsResponse.t()} | {:error, any()}
   def query_moderation_flags(payload, opts \\ []) do
     client = get_client(opts)
@@ -960,26 +757,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.QueryModerationFlagsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -995,10 +779,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.FlagRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec flag(ExStreamClient.Model.FlagRequest.t()) ::
+          {:ok, ExStreamClient.Model.FlagResponse.t()} | {:error, any()}
+  @spec flag(ExStreamClient.Model.FlagRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.FlagResponse.t()} | {:error, any()}
   def flag(payload, opts \\ []) do
     client = get_client(opts)
@@ -1009,26 +795,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.FlagResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -1044,10 +817,12 @@ defmodule ExStreamClient.Operations.Moderation do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.CheckRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec check(ExStreamClient.Model.CheckRequest.t()) ::
+          {:ok, ExStreamClient.Model.CheckResponse.t()} | {:error, any()}
+  @spec check(ExStreamClient.Model.CheckRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.CheckResponse.t()} | {:error, any()}
   def check(payload, opts \\ []) do
     client = get_client(opts)
@@ -1058,26 +833,13 @@ defmodule ExStreamClient.Operations.Moderation do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.CheckResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -1096,6 +858,21 @@ defmodule ExStreamClient.Operations.Moderation do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/og.ex
+++ b/lib/ex_stream_client/operations/og.ex
@@ -16,16 +16,25 @@ defmodule ExStreamClient.Operations.Og do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Get an OpenGraph attachment for a link
 
 
   ### Required Arguments:
   - `url`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_og(String.t()) :: {:ok, ExStreamClient.Model.GetOGResponse.t()} | {:error, any()}
+  @spec get_og(String.t(), shared_opts) ::
+          {:ok, ExStreamClient.Model.GetOGResponse.t()} | {:error, any()}
   def get_og(url, opts \\ []) do
     client = get_client(opts)
     request_opts = [url: "/api/v2/og", method: :get, params: [url: url]] ++ []
@@ -35,26 +44,13 @@ defmodule ExStreamClient.Operations.Og do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetOGResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -73,6 +69,21 @@ defmodule ExStreamClient.Operations.Og do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/rate_limits.ex
+++ b/lib/ex_stream_client/operations/rate_limits.ex
@@ -16,6 +16,13 @@ defmodule ExStreamClient.Operations.RateLimits do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Get rate limits usage and quotas
 
@@ -26,22 +33,17 @@ defmodule ExStreamClient.Operations.RateLimits do
   - `ios`
   - `server_side`
   - `web`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_rate_limits() ::
           {:ok, ExStreamClient.Model.GetRateLimitsResponse.t()} | {:error, any()}
   @spec get_rate_limits([
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:endpoints, String.t()}
-          | {:web, boolean()}
-          | {:ios, boolean()}
-          | {:android, boolean()}
-          | {:server_side, boolean()}
+          ({:endpoints, String.t()}
+           | {:web, boolean()}
+           | {:ios, boolean()}
+           | {:android, boolean()}
+           | {:server_side, boolean()})
+          | shared_opts
         ]) :: {:ok, ExStreamClient.Model.GetRateLimitsResponse.t()} | {:error, any()}
   def get_rate_limits(opts \\ []) do
     client = get_client(opts)
@@ -61,26 +63,13 @@ defmodule ExStreamClient.Operations.RateLimits do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetRateLimitsResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -99,6 +88,21 @@ defmodule ExStreamClient.Operations.RateLimits do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/lib/ex_stream_client/operations/users.ex
+++ b/lib/ex_stream_client/operations/users.ex
@@ -16,6 +16,13 @@ defmodule ExStreamClient.Operations.Users do
   """
   require Logger
 
+  @type shared_opts :: [
+          api_key: String.t(),
+          api_key_secret: String.t(),
+          client: module(),
+          endpoint: String.t(),
+          req_opts: keyword()
+        ]
   @doc ~S"""
   Activates user who's been deactivated previously
 
@@ -26,10 +33,12 @@ defmodule ExStreamClient.Operations.Users do
   ### Required Arguments:
   - `user_id`
   - `payload`: `Elixir.ExStreamClient.Model.ReactivateUserRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec reactivate_user(String.t(), ExStreamClient.Model.ReactivateUserRequest.t()) ::
+          {:ok, ExStreamClient.Model.ReactivateUserResponse.t()} | {:error, any()}
+  @spec reactivate_user(String.t(), ExStreamClient.Model.ReactivateUserRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.ReactivateUserResponse.t()} | {:error, any()}
   def reactivate_user(user_id, payload, opts \\ []) do
     client = get_client(opts)
@@ -43,26 +52,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.ReactivateUserResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -81,10 +77,12 @@ defmodule ExStreamClient.Operations.Users do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.UpdateUsersRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_users(ExStreamClient.Model.UpdateUsersRequest.t()) ::
+          {:ok, ExStreamClient.Model.UpdateUsersResponse.t()} | {:error, any()}
+  @spec update_users(ExStreamClient.Model.UpdateUsersRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.UpdateUsersResponse.t()} | {:error, any()}
   def update_users(payload, opts \\ []) do
     client = get_client(opts)
@@ -95,26 +93,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UpdateUsersResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -135,10 +120,12 @@ defmodule ExStreamClient.Operations.Users do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.UpdateUsersPartialRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec update_users_partial(ExStreamClient.Model.UpdateUsersPartialRequest.t()) ::
+          {:ok, ExStreamClient.Model.UpdateUsersResponse.t()} | {:error, any()}
+  @spec update_users_partial(ExStreamClient.Model.UpdateUsersPartialRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.UpdateUsersResponse.t()} | {:error, any()}
   def update_users_partial(payload, opts \\ []) do
     client = get_client(opts)
@@ -149,26 +136,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.UpdateUsersResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -184,18 +158,11 @@ defmodule ExStreamClient.Operations.Users do
 
   ### Optional Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.QueryUsersPayload`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec query_users() :: {:ok, ExStreamClient.Model.QueryUsersResponse.t()} | {:error, any()}
-  @spec query_users([
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:payload, ExStreamClient.Model.QueryUsersPayload.t()}
-        ]) :: {:ok, ExStreamClient.Model.QueryUsersResponse.t()} | {:error, any()}
+  @spec query_users([{:payload, ExStreamClient.Model.QueryUsersPayload.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.QueryUsersResponse.t()} | {:error, any()}
   def query_users(opts \\ []) do
     client = get_client(opts)
 
@@ -214,26 +181,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.QueryUsersResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -253,10 +207,12 @@ defmodule ExStreamClient.Operations.Users do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.DeleteUsersRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec delete_users(ExStreamClient.Model.DeleteUsersRequest.t()) ::
+          {:ok, ExStreamClient.Model.DeleteUsersResponse.t()} | {:error, any()}
+  @spec delete_users(ExStreamClient.Model.DeleteUsersRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.DeleteUsersResponse.t()} | {:error, any()}
   def delete_users(payload, opts \\ []) do
     client = get_client(opts)
@@ -267,26 +223,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.DeleteUsersResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -306,10 +249,12 @@ defmodule ExStreamClient.Operations.Users do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.ReactivateUsersRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec reactivate_users(ExStreamClient.Model.ReactivateUsersRequest.t()) ::
+          {:ok, ExStreamClient.Model.ReactivateUsersResponse.t()} | {:error, any()}
+  @spec reactivate_users(ExStreamClient.Model.ReactivateUsersRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.ReactivateUsersResponse.t()} | {:error, any()}
   def reactivate_users(payload, opts \\ []) do
     client = get_client(opts)
@@ -320,26 +265,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.ReactivateUsersResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -355,10 +287,12 @@ defmodule ExStreamClient.Operations.Users do
 
   ### Required Arguments:
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec export_user(String.t()) ::
+          {:ok, ExStreamClient.Model.ExportUserResponse.t()} | {:error, any()}
+  @spec export_user(String.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.ExportUserResponse.t()} | {:error, any()}
   def export_user(user_id, opts \\ []) do
     client = get_client(opts)
@@ -369,26 +303,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.ExportUserResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -407,10 +328,12 @@ defmodule ExStreamClient.Operations.Users do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.DeactivateUsersRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec deactivate_users(ExStreamClient.Model.DeactivateUsersRequest.t()) ::
+          {:ok, ExStreamClient.Model.DeactivateUsersResponse.t()} | {:error, any()}
+  @spec deactivate_users(ExStreamClient.Model.DeactivateUsersRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.DeactivateUsersResponse.t()} | {:error, any()}
   def deactivate_users(payload, opts \\ []) do
     client = get_client(opts)
@@ -421,26 +344,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.DeactivateUsersResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -456,10 +366,12 @@ defmodule ExStreamClient.Operations.Users do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.RestoreUsersRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec restore_users(ExStreamClient.Model.RestoreUsersRequest.t()) ::
+          {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
+  @spec restore_users(ExStreamClient.Model.RestoreUsersRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.Response.t()} | {:error, any()}
   def restore_users(payload, opts \\ []) do
     client = get_client(opts)
@@ -470,26 +382,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.Response,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -505,10 +404,12 @@ defmodule ExStreamClient.Operations.Users do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.UnblockUsersRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec unblock_users(ExStreamClient.Model.UnblockUsersRequest.t()) ::
+          {:ok, ExStreamClient.Model.UnblockUsersResponse.t()} | {:error, any()}
+  @spec unblock_users(ExStreamClient.Model.UnblockUsersRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.UnblockUsersResponse.t()} | {:error, any()}
   def unblock_users(payload, opts \\ []) do
     client = get_client(opts)
@@ -519,26 +420,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.UnblockUsersResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -554,10 +442,12 @@ defmodule ExStreamClient.Operations.Users do
 
   ### Required Arguments:
   - `payload`: `Elixir.ExStreamClient.Model.BlockUsersRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec block_users(ExStreamClient.Model.BlockUsersRequest.t()) ::
+          {:ok, ExStreamClient.Model.BlockUsersResponse.t()} | {:error, any()}
+  @spec block_users(ExStreamClient.Model.BlockUsersRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.BlockUsersResponse.t()} | {:error, any()}
   def block_users(payload, opts \\ []) do
     client = get_client(opts)
@@ -568,26 +458,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.BlockUsersResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -603,19 +480,12 @@ defmodule ExStreamClient.Operations.Users do
 
   ### Optional Arguments:
   - `user_id`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec get_blocked_users() ::
           {:ok, ExStreamClient.Model.GetBlockedUsersResponse.t()} | {:error, any()}
-  @spec get_blocked_users([
-          {:req_opts, keyword()}
-          | {:client, module()}
-          | {:endpoint, String.t()}
-          | {:api_key, String.t()}
-          | {:api_key_secret, String.t()}
-          | {:user_id, String.t()}
-        ]) :: {:ok, ExStreamClient.Model.GetBlockedUsersResponse.t()} | {:error, any()}
+  @spec get_blocked_users([{:user_id, String.t()} | shared_opts]) ::
+          {:ok, ExStreamClient.Model.GetBlockedUsersResponse.t()} | {:error, any()}
   def get_blocked_users(opts \\ []) do
     client = get_client(opts)
 
@@ -634,26 +504,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             200 => ExStreamClient.Model.GetBlockedUsersResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -673,10 +530,12 @@ defmodule ExStreamClient.Operations.Users do
   ### Required Arguments:
   - `user_id`
   - `payload`: `Elixir.ExStreamClient.Model.DeactivateUserRequest`
-
-  All options from [Shared Options](#module-shared-options) are supported.
+  ### Optional Arguments:
+  - All options from [Shared Options](#module-shared-options) are supported.
   """
   @spec deactivate_user(String.t(), ExStreamClient.Model.DeactivateUserRequest.t()) ::
+          {:ok, ExStreamClient.Model.DeactivateUserResponse.t()} | {:error, any()}
+  @spec deactivate_user(String.t(), ExStreamClient.Model.DeactivateUserRequest.t(), shared_opts) ::
           {:ok, ExStreamClient.Model.DeactivateUserResponse.t()} | {:error, any()}
   def deactivate_user(user_id, payload, opts \\ []) do
     client = get_client(opts)
@@ -690,26 +549,13 @@ defmodule ExStreamClient.Operations.Users do
       Req.new(request_opts)
       |> Req.Request.append_response_steps(
         decode: fn {request, response} ->
-          response_type =
-            if response.status in 200..299 do
-              :ok
-            else
-              :error
-            end
-
           response_handlers = %{
             201 => ExStreamClient.Model.DeactivateUserResponse,
             400 => ExStreamClient.Model.APIError,
             429 => ExStreamClient.Model.APIError
           }
 
-          parsed =
-            case Map.get(response_handlers, response.status) do
-              nil -> {:error, response.body}
-              mod -> {response_type, mod.decode(response.body)}
-            end
-
-          {request, %{response | body: parsed}}
+          {request, %{response | body: decode_response(response, response_handlers)}}
         end
       )
 
@@ -728,6 +574,21 @@ defmodule ExStreamClient.Operations.Users do
     end
 
     client
+  end
+
+  defp decode_response(response, response_handlers) do
+    case Map.get(response_handlers, response.status) do
+      nil -> {:error, response.body}
+      mod -> {get_response_type(response), mod.decode(response.body)}
+    end
+  end
+
+  defp get_response_type(response) do
+    if response.status in 200..299 do
+      :ok
+    else
+      :error
+    end
   end
 
   defp get_request_opts(opts) do

--- a/tools/codegen/generate_operations.ex
+++ b/tools/codegen/generate_operations.ex
@@ -124,9 +124,16 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
               end
             end
 
-          spec_ast =
+          required_spec_ast =
             quote do
               # fx without opts
+              @spec unquote(name)(unquote_splicing(spec)) ::
+                      unquote(response_spec) | {:error, any()}
+            end
+
+          optional_spec_ast =
+            quote do
+              # fx with opts
               @spec unquote(name)(unquote_splicing(spec), unquote(optional_args)) ::
                       unquote(response_spec) | {:error, any()}
             end
@@ -268,10 +275,12 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
               end
             end
 
-          []
-          |> maybe_append(true, doc_ast)
-          |> maybe_append(true, spec_ast)
-          |> maybe_append(true, method_impl_ast)
+          [
+            doc_ast,
+            required_spec_ast,
+            optional_spec_ast,
+            method_impl_ast
+          ]
         end)
 
       moduledoc_string =

--- a/tools/codegen/generate_operations.ex
+++ b/tools/codegen/generate_operations.ex
@@ -66,7 +66,25 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
             build_arg_docstring(merged_optional_args |> Enum.sort_by(& &1.name))
 
           merged_optional_args =
-            Enum.concat(merged_optional_args, [
+            [
+              %{
+                in: "opts",
+                name: "req_opts",
+                type: "keyword",
+                description:
+                  "all of these options will be forwarded to req. See `Req.new/1` for available options",
+                required?: false,
+                example: "[plug: MyTest.Plug]"
+              },
+              %{
+                in: "opts",
+                name: "endpoint",
+                type: "string",
+                description:
+                  "Endpoint to use. If not provided, the default endpoint from config will be used.",
+                required?: false,
+                example: "ExStreamClient.Config.endpoint()"
+              },
               %{
                 in: "opts",
                 name: "api_key_secret",
@@ -87,31 +105,13 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
               },
               %{
                 in: "opts",
-                name: "endpoint",
-                type: "string",
-                description:
-                  "Endpoint to use. If not provided, the default endpoint from config will be used.",
-                required?: false,
-                example: "ExStreamClient.Config.endpoint()"
-              },
-              %{
-                in: "opts",
                 name: "client",
                 type: "module",
                 description: "HTTP client to use. Must implement `ExStreamClient.Http.Behavior`",
                 required?: false,
                 example: "ExStreamClient.Http"
-              },
-              %{
-                in: "opts",
-                name: "req_opts",
-                type: "keyword",
-                description:
-                  "all of these options will be forwarded to req. See `Req.new/1` for available options",
-                required?: false,
-                example: "[plug: MyTest.Plug]"
               }
-            ])
+            ] ++ merged_optional_args
 
           # convert non-optional args into [arg1, arg2, arg3] representation
           arg_names =
@@ -161,23 +161,11 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
               e -> [e]
             end
 
-          required_spec_ast =
+          spec_ast =
             quote do
               # fx without opts
-              @spec unquote(name)(unquote_splicing(spec)) ::
+              @spec unquote(name)(unquote_splicing(spec), unquote(optional_args)) ::
                       unquote(response_spec) | {:error, any()}
-            end
-
-          optional_spec_ast =
-            if has_optional_args? do
-              quote do
-                # fx with opts
-                @spec unquote(name)(unquote_splicing(spec), unquote(optional_args)) ::
-                        unquote(response_spec) | {:error, any()}
-              end
-            else
-              quote do
-              end
             end
 
           description_str = if(description == "", do: summary, else: description)
@@ -188,12 +176,11 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
                      [format_events_as_code(description_str), ""]
                      |> maybe_append(merged_required_args != [], "### Required Arguments:")
                      |> maybe_append(merged_required_args != [], "#{required_args_docstring}")
-                     |> maybe_append(has_optional_args?, "### Optional Arguments:")
+                     |> maybe_append(true, "### Optional Arguments:")
                      |> maybe_append(has_optional_args?, "#{optional_args_docstring}")
-                     |> maybe_append(true, "")
                      |> maybe_append(
                        true,
-                       "All options from [Shared Options](#module-shared-options) are supported."
+                       "- All options from [Shared Options](#module-shared-options) are supported."
                      )
                      |> maybe_append(true, "")
                      |> Enum.join("\n")
@@ -303,19 +290,11 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
                   Req.new(request_opts)
                   |> Req.Request.append_response_steps(
                     decode: fn {request, response} ->
-                      response_type = if response.status in 200..299, do: :ok, else: :error
-
                       response_handlers = %{
                         unquote_splicing(response_handlers)
                       }
 
-                      parsed =
-                        case Map.get(response_handlers, response.status) do
-                          nil -> {:error, response.body}
-                          mod -> {response_type, mod.decode(response.body)}
-                        end
-
-                      {request, %{response | body: parsed}}
+                      {request, %{response | body: decode_response(response, response_handlers)}}
                     end
                   )
 
@@ -328,8 +307,7 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
 
           []
           |> maybe_append(true, doc_ast)
-          |> maybe_append(true, required_spec_ast)
-          |> maybe_append(has_optional_args?, optional_spec_ast)
+          |> maybe_append(true, spec_ast)
           |> maybe_append(true, method_impl_ast)
         end)
 
@@ -367,6 +345,16 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
 
               client
             end
+
+            defp decode_response(response, response_handlers) do
+              case Map.get(response_handlers, response.status) do
+                nil -> {:error, response.body}
+                mod -> {get_response_type(response), mod.decode(response.body)}
+              end
+            end
+
+            defp get_response_type(response),
+              do: if(response.status in 200..299, do: :ok, else: :error)
 
             defp get_request_opts(opts) do
               Keyword.take(


### PR DESCRIPTION
Does a few things: 

- Improves the typespecs now that we've added back shared optional args, so that the opts are reflected in the spec.
- Ensures optional args from the spec (which aren't shared) are presented first in spec. They're likely the most relevant for a reader to know.
- Moves the shared optional args into a type on the module so it can be reused.
- Ensures optional args header is added to all methods - and optional args from the spec are presented first. 
- Improves codegen to pull out some helper methods. This reduces file size of large operations files substantially. 