### PR TITLE
fix(ExStreamClient.JSON): only transform existing keys to atoms

### DIFF
--- a/lib/ex_stream_client/json.ex
+++ b/lib/ex_stream_client/json.ex
@@ -21,13 +21,20 @@ defmodule ExStreamClient.JSON do
       Build a struct from a map, transforming nested components and atom fields.
       """
       def decode(map) when is_map(map) do
+        valid_keys =
+          struct(__MODULE__, %{})
+          |> Map.from_struct()
+          |> Map.keys()
+          |> Enum.map(&to_string/1)
+
         # Now that the module is loaded, convert to atom keys
-        map = for {k, v} <- map, into: %{}, do: {transform(Macro.underscore(k), :atom), v}
+        map =
+          for {k, v} <- map, into: %{}, do: {transform(Macro.underscore(k), :atom, valid_keys), v}
 
         processed =
           Enum.reduce(nested_components(), map, fn {key, type_or_mod}, acc ->
             case Map.fetch(acc, key) do
-              {:ok, val} -> Map.put(acc, key, transform(val, type_or_mod))
+              {:ok, val} -> Map.put(acc, key, transform(val, type_or_mod, :all))
               :error -> acc
             end
           end)
@@ -39,10 +46,10 @@ defmodule ExStreamClient.JSON do
       Components could just be enums that are typed - so we need to decode those as enums as they will just be stings
       """
       def decode(map) when is_binary(map) do
-        transform(map, :atom)
+        transform(map, :atom, :all)
       end
 
-      defp transform(val, :atom) when is_binary(val) do
+      defp transform(val, :atom, :all) when is_binary(val) do
         String.to_existing_atom(val)
       rescue
         ArgumentError ->
@@ -53,21 +60,32 @@ defmodule ExStreamClient.JSON do
           val
       end
 
-      defp transform(val, :atom) when is_list(val), do: Enum.map(val, &transform(&1, :atom))
+      defp transform(val, :atom, valid_keys) when is_binary(val) do
+        if val in valid_keys do
+          String.to_existing_atom(val)
+        else
+          val
+        end
+      end
 
-      defp transform(val, {:map, {:array, {:component, mod}}}) when is_map(val),
+      defp transform(val, :atom, valid_keys) when is_list(val),
+        do: Enum.map(val, &transform(&1, :atom, :all))
+
+      defp transform(val, {:map, {:array, {:component, mod}}}, valid_keys) when is_map(val),
         do:
           Enum.map(val, fn {k, v} ->
-            {transform(k, :atom), Enum.map(v, &transform(&1, mod))}
+            {transform(k, :atom, :all), Enum.map(v, &transform(&1, mod, :all))}
           end)
           |> Enum.into(%{})
 
-      defp transform(val, {:map, mod}) when is_map(val),
+      defp transform(val, {:map, mod}, valid_keys) when is_map(val),
         do:
-          Enum.map(val, fn {k, v} -> {transform(k, :atom), transform(v, mod)} end)
+          Enum.map(val, fn {k, v} ->
+            {transform(k, :atom, :app), transform(v, mod, :all)}
+          end)
           |> Enum.into(%{})
 
-      defp transform(val, mod) when is_list(val) and is_atom(mod) do
+      defp transform(val, mod, _) when is_list(val) and is_atom(mod) do
         if Code.ensure_loaded?(mod) and function_exported?(mod, :decode, 1) do
           Enum.map(val, &mod.decode/1)
         else
@@ -75,7 +93,7 @@ defmodule ExStreamClient.JSON do
         end
       end
 
-      defp transform(val, mod) when is_map(val) and is_atom(mod) do
+      defp transform(val, mod, _) when is_map(val) and is_atom(mod) do
         if Code.ensure_loaded?(mod) and function_exported?(mod, :decode, 1) do
           mod.decode(val)
         else
@@ -84,7 +102,7 @@ defmodule ExStreamClient.JSON do
       end
 
       # Fallback
-      defp transform(val, _), do: val
+      defp transform(val, _, _), do: val
     end
   end
 end


### PR DESCRIPTION
Previously, all map keys were converted to atoms, and if the atom did not exist, the ArgumentError would be rescued and an entry logged.

However, in some circumstances, the key should be treated as a string. For example, when creating users, the response is:

```
"7332714135366402048" => %ExStreamClient.Model.FullUserResponse{
...
  updated_at: 1750070497005033000
},
"7332714224709271552" => %ExStreamClient.Model.FullUserResponse{
...
  updated_at: 1750070497005033000
}
```

In this case, the map keys are strings that will not exist in the atoms table, as they represent use ids. To fix this, a list of valid keys is now determined from the struct and used when checking which keys to transform to atoms. This is only the case for the top level struct, nested structs use the existing `String.to_existing_atom` method.