### PR TITLE
feat: allow for overrides of properties on objects

### DIFF
--- a/lib/ex_stream_client/model/message_new_event.ex
+++ b/lib/ex_stream_client/model/message_new_event.ex
@@ -4,11 +4,17 @@ defmodule ExStreamClient.Model.MessageNewEvent do
   use ExStreamClient.TypeInterner
   @enforce_keys [:channel_id, :channel_type, :cid, :created_at, :type, :watcher_count]
   defstruct [
+    :channel,
+    :channel_custom,
     :channel_id,
+    :channel_last_message_at,
+    :channel_member_count,
     :channel_type,
     :cid,
     :created_at,
+    :members,
     :message,
+    :message_id,
     :team,
     :thread_participants,
     :type,
@@ -16,7 +22,9 @@ defmodule ExStreamClient.Model.MessageNewEvent do
     :watcher_count
   ]
 
-  @nested_components message: ExStreamClient.Model.Message,
+  @nested_components channel: ExStreamClient.Model.Channel,
+                     members: ExStreamClient.Model.ChannelMember,
+                     message: ExStreamClient.Model.Message,
                      thread_participants: ExStreamClient.Model.User,
                      user: ExStreamClient.Model.User
   def nested_components do
@@ -24,11 +32,17 @@ defmodule ExStreamClient.Model.MessageNewEvent do
   end
 
   @type t :: %__MODULE__{
+          channel: ExStreamClient.Model.Channel.t() | nil,
+          channel_custom: %{optional(String.t()) => any()} | nil,
           channel_id: String.t(),
+          channel_last_message_at: String.t() | nil,
+          channel_member_count: integer() | nil,
           channel_type: String.t(),
           cid: String.t(),
           created_at: float(),
+          members: [ExStreamClient.Model.ChannelMember.t()] | nil,
           message: ExStreamClient.Model.Message.t() | nil,
+          message_id: String.t() | nil,
           team: String.t() | nil,
           thread_participants: [ExStreamClient.Model.User.t()] | nil,
           type: String.t(),

--- a/lib/ex_stream_client/model/user.ex
+++ b/lib/ex_stream_client/model/user.ex
@@ -6,6 +6,8 @@ defmodule ExStreamClient.Model.User do
   defstruct [
     :ban_expires,
     :banned,
+    :channel_last_read_at,
+    :channel_unread_count,
     :created_at,
     :custom,
     :deactivated_at,
@@ -21,6 +23,7 @@ defmodule ExStreamClient.Model.User do
     :role,
     :teams,
     :teams_role,
+    :unread_thread_messages,
     :updated_at
   ]
 
@@ -32,6 +35,8 @@ defmodule ExStreamClient.Model.User do
   @type t :: %__MODULE__{
           ban_expires: float() | nil,
           banned: boolean(),
+          channel_last_read_at: String.t() | nil,
+          channel_unread_count: integer() | nil,
           created_at: float() | nil,
           custom: %{optional(String.t()) => any()},
           deactivated_at: float() | nil,
@@ -47,6 +52,7 @@ defmodule ExStreamClient.Model.User do
           role: String.t(),
           teams: [String.t()] | nil,
           teams_role: %{optional(String.t()) => String.t()},
+          unread_thread_messages: integer() | nil,
           updated_at: float() | nil
         }
 end

--- a/tools/spec/overrides.ex
+++ b/tools/spec/overrides.ex
@@ -1,0 +1,22 @@
+defmodule ExStreamClient.Tools.Spec.Overrides do
+  def model_overrides(),
+    do: %{
+      "MessageNewEvent" => %{
+        additional_fields: [
+          %{name: "channel", type: {:component, "Channel"}, required: false},
+          %{name: "channel_custom", type: {:map, :any}, required: false},
+          %{name: "channel_last_message_at", type: "string", required: false},
+          %{name: "channel_member_count", type: "integer", required: false},
+          %{name: "members", type: {:array, {:component, "ChannelMember"}}, required: false},
+          %{name: "message_id", type: "string", required: false}
+        ]
+      },
+      "User" => %{
+        additional_fields: [
+          %{name: "channel_last_read_at", type: "string", required: false},
+          %{name: "channel_unread_count", type: "integer", required: false},
+          %{name: "unread_thread_messages", type: "integer", required: false}
+        ]
+      }
+    }
+end


### PR DESCRIPTION
Allows for overriding modules with additional properties in a way that won't be impacted with updates.

Noticed that some events / responses have either new fields not yet exposed in a spec OR are just missing. For example, `MessageNewEvent` contains `channel` property, which has useful metadata for pushing (channel config has `push_notification` config, which can be disabled).

Figured this was a quick way to get these added without it getting clobbered in when updating.