### PR TITLE
feat: allow authenticate_as_user for user JWT tokens

### DIFF
--- a/lib/ex_stream_client/http.ex
+++ b/lib/ex_stream_client/http.ex
@@ -25,7 +25,13 @@ defmodule ExStreamClient.Http do
     response_handlers = Keyword.get(opts, :response_handlers, %{})
 
     token =
-      case ExStreamClient.Token.Server.get(api_key, api_key_secret) do
+      case Keyword.get(opts, :authenticate_as_user) do
+        nil -> ExStreamClient.Token.Server.get(api_key, api_key_secret)
+        user_id -> ExStreamClient.Token.User.get(user_id, nil, api_key_secret)
+      end
+
+    token =
+      case token do
         {:ok, token} ->
           token
 

--- a/lib/ex_stream_client/operations/app.ex
+++ b/lib/ex_stream_client/operations/app.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.App do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.App do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -98,6 +100,6 @@ defmodule ExStreamClient.Operations.App do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/blocklists.ex
+++ b/lib/ex_stream_client/operations/blocklists.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Blocklists do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Blocklists do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -235,6 +237,6 @@ defmodule ExStreamClient.Operations.Blocklists do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/campaigns.ex
+++ b/lib/ex_stream_client/operations/chat/campaigns.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -191,6 +193,6 @@ defmodule ExStreamClient.Operations.Chat.Campaigns do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/channels.ex
+++ b/lib/ex_stream_client/operations/chat/channels.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -1076,6 +1078,6 @@ defmodule ExStreamClient.Operations.Chat.Channels do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/channeltypes.ex
+++ b/lib/ex_stream_client/operations/chat/channeltypes.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -208,6 +210,6 @@ defmodule ExStreamClient.Operations.Chat.Channeltypes do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/commands.ex
+++ b/lib/ex_stream_client/operations/chat/commands.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Commands do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Commands do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -201,6 +203,6 @@ defmodule ExStreamClient.Operations.Chat.Commands do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/drafts.ex
+++ b/lib/ex_stream_client/operations/chat/drafts.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Drafts do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Drafts do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -71,6 +73,6 @@ defmodule ExStreamClient.Operations.Chat.Drafts do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/export_channels.ex
+++ b/lib/ex_stream_client/operations/chat/export_channels.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.ExportChannels do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.ExportChannels do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -71,6 +73,6 @@ defmodule ExStreamClient.Operations.Chat.ExportChannels do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/members.ex
+++ b/lib/ex_stream_client/operations/chat/members.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Members do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Members do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -75,6 +77,6 @@ defmodule ExStreamClient.Operations.Chat.Members do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/messages.ex
+++ b/lib/ex_stream_client/operations/chat/messages.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -904,6 +906,6 @@ defmodule ExStreamClient.Operations.Chat.Messages do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/moderation.ex
+++ b/lib/ex_stream_client/operations/chat/moderation.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -158,6 +160,6 @@ defmodule ExStreamClient.Operations.Chat.Moderation do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/push_preferences.ex
+++ b/lib/ex_stream_client/operations/chat/push_preferences.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.PushPreferences do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.PushPreferences do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -74,6 +76,6 @@ defmodule ExStreamClient.Operations.Chat.PushPreferences do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/push_templates.ex
+++ b/lib/ex_stream_client/operations/chat/push_templates.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.PushTemplates do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.PushTemplates do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -117,6 +119,6 @@ defmodule ExStreamClient.Operations.Chat.PushTemplates do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/query_banned_users.ex
+++ b/lib/ex_stream_client/operations/chat/query_banned_users.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.QueryBannedUsers do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.QueryBannedUsers do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -77,6 +79,6 @@ defmodule ExStreamClient.Operations.Chat.QueryBannedUsers do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/reminders.ex
+++ b/lib/ex_stream_client/operations/chat/reminders.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Reminders do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Reminders do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -71,6 +73,6 @@ defmodule ExStreamClient.Operations.Chat.Reminders do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/search.ex
+++ b/lib/ex_stream_client/operations/chat/search.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Search do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Search do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -75,6 +77,6 @@ defmodule ExStreamClient.Operations.Chat.Search do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/segments.ex
+++ b/lib/ex_stream_client/operations/chat/segments.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Segments do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Segments do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -255,6 +257,6 @@ defmodule ExStreamClient.Operations.Chat.Segments do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/threads.ex
+++ b/lib/ex_stream_client/operations/chat/threads.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Threads do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Threads do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -161,6 +163,6 @@ defmodule ExStreamClient.Operations.Chat.Threads do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/unread.ex
+++ b/lib/ex_stream_client/operations/chat/unread.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Unread do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Unread do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -66,6 +68,6 @@ defmodule ExStreamClient.Operations.Chat.Unread do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/unread_batch.ex
+++ b/lib/ex_stream_client/operations/chat/unread_batch.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.UnreadBatch do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.UnreadBatch do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -71,6 +73,6 @@ defmodule ExStreamClient.Operations.Chat.UnreadBatch do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/chat/users.ex
+++ b/lib/ex_stream_client/operations/chat/users.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Chat.Users do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Chat.Users do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -78,6 +80,6 @@ defmodule ExStreamClient.Operations.Chat.Users do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/check_push.ex
+++ b/lib/ex_stream_client/operations/check_push.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.CheckPush do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.CheckPush do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -68,6 +70,6 @@ defmodule ExStreamClient.Operations.CheckPush do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/check_sns.ex
+++ b/lib/ex_stream_client/operations/check_sns.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.CheckSns do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.CheckSns do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -68,6 +70,6 @@ defmodule ExStreamClient.Operations.CheckSns do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/check_sqs.ex
+++ b/lib/ex_stream_client/operations/check_sqs.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.CheckSqs do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.CheckSqs do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -68,6 +70,6 @@ defmodule ExStreamClient.Operations.CheckSqs do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/devices.ex
+++ b/lib/ex_stream_client/operations/devices.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Devices do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Devices do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -150,6 +152,6 @@ defmodule ExStreamClient.Operations.Devices do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/export.ex
+++ b/lib/ex_stream_client/operations/export.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Export do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Export do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -68,6 +70,6 @@ defmodule ExStreamClient.Operations.Export do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/external_storage.ex
+++ b/lib/ex_stream_client/operations/external_storage.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.ExternalStorage do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.ExternalStorage do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -207,6 +209,6 @@ defmodule ExStreamClient.Operations.ExternalStorage do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/guest.ex
+++ b/lib/ex_stream_client/operations/guest.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Guest do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Guest do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -68,6 +70,6 @@ defmodule ExStreamClient.Operations.Guest do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/import_urls.ex
+++ b/lib/ex_stream_client/operations/import_urls.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.ImportUrls do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.ImportUrls do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -68,6 +70,6 @@ defmodule ExStreamClient.Operations.ImportUrls do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/imports.ex
+++ b/lib/ex_stream_client/operations/imports.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Imports do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Imports do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -131,6 +133,6 @@ defmodule ExStreamClient.Operations.Imports do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/moderation.ex
+++ b/lib/ex_stream_client/operations/moderation.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Moderation do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Moderation do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -761,6 +763,6 @@ defmodule ExStreamClient.Operations.Moderation do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/og.ex
+++ b/lib/ex_stream_client/operations/og.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Og do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Og do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -67,6 +69,6 @@ defmodule ExStreamClient.Operations.Og do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/permissions.ex
+++ b/lib/ex_stream_client/operations/permissions.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Permissions do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Permissions do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -99,6 +101,6 @@ defmodule ExStreamClient.Operations.Permissions do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/polls.ex
+++ b/lib/ex_stream_client/operations/polls.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Polls do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Polls do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -510,6 +512,6 @@ defmodule ExStreamClient.Operations.Polls do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/push_providers.ex
+++ b/lib/ex_stream_client/operations/push_providers.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.PushProviders do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.PushProviders do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -136,6 +138,6 @@ defmodule ExStreamClient.Operations.PushProviders do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/rate_limits.ex
+++ b/lib/ex_stream_client/operations/rate_limits.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.RateLimits do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.RateLimits do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -86,6 +88,6 @@ defmodule ExStreamClient.Operations.RateLimits do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/roles.ex
+++ b/lib/ex_stream_client/operations/roles.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Roles do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Roles do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -130,6 +132,6 @@ defmodule ExStreamClient.Operations.Roles do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/tasks.ex
+++ b/lib/ex_stream_client/operations/tasks.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Tasks do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Tasks do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -67,6 +69,6 @@ defmodule ExStreamClient.Operations.Tasks do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/uploads.ex
+++ b/lib/ex_stream_client/operations/uploads.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Uploads do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Uploads do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -181,6 +183,6 @@ defmodule ExStreamClient.Operations.Uploads do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/lib/ex_stream_client/operations/users.ex
+++ b/lib/ex_stream_client/operations/users.ex
@@ -9,6 +9,7 @@ defmodule ExStreamClient.Operations.Users do
   All functions in this module accept the following optional parameters:
 
    * `api_key` - API key to use. If not provided, the default key from config will be used
+   * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used
    * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used
    * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used
    * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`
@@ -19,6 +20,7 @@ defmodule ExStreamClient.Operations.Users do
   @type shared_opts :: [
           api_key: String.t(),
           api_key_secret: String.t(),
+          authenticate_as_user: String.t(),
           client: module(),
           endpoint: String.t(),
           req_opts: keyword()
@@ -597,6 +599,6 @@ defmodule ExStreamClient.Operations.Users do
   end
 
   defp get_request_opts(opts) do
-    Keyword.take(opts, [:api_key, :api_key_secret, :endpoint])
+    Keyword.take(opts, [:api_key, :api_key_secret, :authenticate_as_user, :endpoint])
   end
 end

--- a/tools/codegen/generate_operations.ex
+++ b/tools/codegen/generate_operations.ex
@@ -287,6 +287,7 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
           "All functions in this module accept the following optional parameters:",
           "",
           " * `api_key` - API key to use. If not provided, the default key from config will be used",
+          " * `authenticate_as_user` - User id to authenticate. If not provided, the server key will be used",
           " * `api_key_secret` - API key secret to use. If not provided, the default secret from config will be used",
           " * `endpoint` - endpoint to use. If not provided, the default endpoint from config will be used",
           " * `client` - HTTP client to use. Must implement `ExStreamClient.Http.Behavior`. Defaults to `ExStreamClient.Http`",
@@ -313,6 +314,14 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
             "API key secret to use. If not provided, the default secret from config will be used.",
           required?: false,
           example: "ExStreamClient.Config.api_key_secret()"
+        },
+        %{
+          in: "opts",
+          name: "authenticate_as_user",
+          type: "string",
+          description: "User id to authenticate. If not provided, the server key will be used.",
+          required?: false,
+          example: "user_123"
         },
         %{
           in: "opts",
@@ -374,7 +383,7 @@ defmodule ExStreamClient.Tools.Codegen.GenerateOperations do
             defp get_request_opts(opts) do
               Keyword.take(
                 opts,
-                [:api_key, :api_key_secret, :endpoint]
+                [:api_key, :api_key_secret, :authenticate_as_user, :endpoint]
               )
             end
           end


### PR DESCRIPTION
Some API calls mandate that a user is used for the API authentication, whilst others allow it optionally. Instead of trying to figure out which ones allow it and which don't, the user can provide an `authenticate_as_user` option, which if provided, will use a user authentication token instead of a server one.